### PR TITLE
Add Nullable types and Mail API change

### DIFF
--- a/models/db.go
+++ b/models/db.go
@@ -157,6 +157,11 @@ func generateSQLStmt(mode string, tableName string, input ...interface{}) (query
 					fmt.Println("valid NullInt : ", field.Int)
 					columns = append(columns, tag.Get("db"))
 				}
+			case NullBool:
+				if field.Valid {
+					fmt.Println("valid NullBool : ", field.Bool)
+					columns = append(columns, tag.Get("db"))
+				}
 			case bool, int, uint32:
 				columns = append(columns, tag.Get("db"))
 			default:

--- a/models/db.go
+++ b/models/db.go
@@ -152,6 +152,11 @@ func generateSQLStmt(mode string, tableName string, input ...interface{}) (query
 					fmt.Println("valid NullTime : ", field.Time)
 					columns = append(columns, tag.Get("db"))
 				}
+			case NullInt:
+				if field.Valid {
+					fmt.Println("valid NullInt : ", field.Int)
+					columns = append(columns, tag.Get("db"))
+				}
 			case bool, int, uint32:
 				columns = append(columns, tag.Get("db"))
 			default:

--- a/models/members.go
+++ b/models/members.go
@@ -34,11 +34,11 @@ type Member struct {
 	Role   NullInt `json:"role" db:"role"`
 	Active NullInt `json:"active" db:"active"`
 
-	CustomEditor bool `json:"custom_editor" db:"c_editor"`
-	HideProfile  bool `json:"hide_profile" db:"hide_profile"`
-	ProfilePush  bool `json:"profile_push" db:"profile_push"`
-	PostPush     bool `json:"post_push" db:"post_push"`
-	CommentPush  bool `json:"comment_push" db:"comment_push"`
+	CustomEditor NullBool `json:"custom_editor" db:"c_editor"`
+	HideProfile  NullBool `json:"hide_profile" db:"hide_profile"`
+	ProfilePush  NullBool `json:"profile_push" db:"profile_push"`
+	PostPush     NullBool `json:"post_push" db:"post_push"`
+	CommentPush  NullBool `json:"comment_push" db:"comment_push"`
 }
 
 // Separate API and Member struct

--- a/models/members.go
+++ b/models/members.go
@@ -31,8 +31,8 @@ type Member struct {
 	ProfileImage NullString `json:"profile_image" db:"profile_picture"`
 	Identity     NullString `json:"identity" db:"identity"`
 
-	Role   int `json:"role" db:"role"`
-	Active int `json:"active" db:"active"`
+	Role   NullInt `json:"role" db:"role"`
+	Active NullInt `json:"active" db:"active"`
 
 	CustomEditor bool `json:"custom_editor" db:"c_editor"`
 	HideProfile  bool `json:"hide_profile" db:"hide_profile"`

--- a/models/permissions.go
+++ b/models/permissions.go
@@ -13,7 +13,7 @@ import (
 type Permission struct {
 	Role       int        `json:"role" db:"role"`
 	Object     NullString `json:"object" db:"object"`
-	Permission int        `json:"permission" db:"permission"`
+	Permission NullInt    `json:"permission" db:"permission"`
 }
 
 type PermissionAPIImpl struct{}

--- a/models/projects.go
+++ b/models/projects.go
@@ -16,10 +16,10 @@ type Project struct {
 	UpdatedBy   NullString `json:"updated_by" db:"updated_by"`
 	PublishedAt NullString `json:"published_at" db:"published_at"`
 
-	PostID        int `json:"post_id" db:"post_id"`
-	LikeAmount    int `json:"like_amount" db:"like_amount"`
-	CommentAmount int `json:"comment_amount" db:"comment_amount"`
-	Active        int `json:"active" db:"active"`
+	PostID        int     `json:"post_id" db:"post_id"`
+	LikeAmount    NullInt `json:"like_amount" db:"like_amount"`
+	CommentAmount NullInt `json:"comment_amount" db:"comment_amount"`
+	Active        NullInt `json:"active" db:"active"`
 
 	HeroImage     NullString `json:"hero_image" db:"hero_image"`
 	Title         NullString `json:"title" db:"title"`

--- a/routes/auth.go
+++ b/routes/auth.go
@@ -34,7 +34,7 @@ func (r *authHandler) userLogin(c *gin.Context) {
 	}
 
 	id, password, mode := p.ID, p.Password, p.Mode
-	//fmt.Printf("id: %v, pwd: %v, mode: %v, p:%v", id, password, mode, p)
+	// fmt.Printf("id: %v, pwd: %v, mode: %v, p:%v\n", id, password, mode, p)
 
 	switch {
 	case !utils.ValidateUserID(id), !validateMode(mode):
@@ -57,7 +57,7 @@ func (r *authHandler) userLogin(c *gin.Context) {
 		}
 	}
 
-	if member.Active == 0 {
+	if member.Active.Int == 0 {
 		c.JSON(http.StatusUnauthorized, gin.H{"Error": "User Not Activated"})
 		return
 	}
@@ -88,7 +88,7 @@ func (r *authHandler) userLogin(c *gin.Context) {
 	// 4. get user permission by id
 	// 5. return user's profile and permission info
 
-	userPermissions, err := models.PermissionAPI.GetPermissionsByRole(member.Role)
+	userPermissions, err := models.PermissionAPI.GetPermissionsByRole(int(member.Role.Int))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"Error": "Internal Server Error"})
 		return
@@ -166,7 +166,7 @@ func (r *authHandler) userRegister(c *gin.Context) {
 
 		member.Salt = models.NullString{string(salt), true}
 		member.Password = models.NullString{string(hpw), true}
-		member.Active = 0
+		member.Active = models.NullInt{0, true}
 
 	} else {
 
@@ -175,7 +175,7 @@ func (r *authHandler) userRegister(c *gin.Context) {
 			return
 		}
 
-		member.Active = 1
+		member.Active = models.NullInt{1, true}
 	}
 
 	// 4. create Member object, fill in data and defaults

--- a/routes/auth_test.go
+++ b/routes/auth_test.go
@@ -31,22 +31,22 @@ func initAuthTest() {
 		models.Member{
 			ID:           "logintest1@mirrormedia.mg",
 			Password:     models.NullString{"hellopassword", true},
-			Role:         1,
-			Active:       1,
+			Role:         models.NullInt{1, true},
+			Active:       models.NullInt{1, true},
 			RegisterMode: models.NullString{"ordinary", true},
 		},
 		models.Member{
 			ID:           "logintest2018",
 			Password:     models.NullString{"1233211234567", true},
-			Role:         1,
-			Active:       1,
+			Role:         models.NullInt{1, true},
+			Active:       models.NullInt{1, true},
 			RegisterMode: models.NullString{"oauth-fb", true},
 		},
 		models.Member{
 			ID:           "logindeactived",
 			Password:     models.NullString{"88888888", true},
-			Role:         1,
-			Active:       0,
+			Role:         models.NullInt{1, true},
+			Active:       models.NullInt{0, true},
 			RegisterMode: models.NullString{"ordinary", true},
 		}}
 

--- a/routes/member_test.go
+++ b/routes/member_test.go
@@ -93,7 +93,7 @@ func (mapi *mockMemberAPI) DeleteMember(id string) (models.Member, error) {
 	err := errors.New("User Not Found")
 	for index, value := range mockMemberDS {
 		if id == value.ID {
-			mockMemberDS[index].Active = 0
+			mockMemberDS[index].Active = models.NullInt{0, true}
 			return mockMemberDS[index], nil
 		}
 	}
@@ -311,7 +311,7 @@ func TestDeleteExistMember(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		log.Fatal(err)
 	}
-	if resp.Active == 1 {
+	if resp.Active.Int == 1 {
 		t.Fail()
 	}
 }

--- a/routes/misc.go
+++ b/routes/misc.go
@@ -16,6 +16,8 @@ func (r *miscHandler) sendMail(c *gin.Context) {
 
 	input := struct {
 		Receiver []string `json:"receiver"`
+		CC       []string `json:"cc"`
+		BCC      []string `json:"bcc"`
 		Subject  string   `json:"subject"`
 		Payload  string   `json:"content"`
 	}{}
@@ -29,6 +31,8 @@ func (r *miscHandler) sendMail(c *gin.Context) {
 	m := gomail.NewMessage()
 	m.SetHeader("From", r.Dialer.Username)
 	m.SetHeader("To", input.Receiver...)
+	m.SetHeader("Cc", input.CC...)
+	m.SetHeader("Bcc", input.BCC...)
 	m.SetHeader("Subject", input.Subject)
 	m.SetBody("text/html", input.Payload)
 

--- a/routes/misc_test.go
+++ b/routes/misc_test.go
@@ -34,7 +34,9 @@ func initMailDialer() gomail.Dialer {
 func TestRouteSendEmail(t *testing.T) {
 
 	type SendEmailCaseIn struct {
-		Receiver []string `receiver:id,omitempty`
+		Receiver []string `json:receiver,omitempty`
+		CC       []string `json:cc,omitempty`
+		BCC      []string `json:bcc,omitempty`
 		Subject  string   `json:"subject,omitempty"`
 		Payload  string   `json:"content,omitempty"`
 	}
@@ -44,9 +46,11 @@ func TestRouteSendEmail(t *testing.T) {
 		in       SendEmailCaseIn
 		httpcode int
 	}{
-		{"SendMailOK", SendEmailCaseIn{Receiver: []string{"yychen@mirrormedia.mg"}, Subject: "TestSuccess", Payload: "<b>HTML</b> payload"}, http.StatusOK},
-		{"SendMail2RecvOK", SendEmailCaseIn{Receiver: []string{"yychen@mirrormedia.mg"}, Subject: "TestSuccess", Payload: "<b>HTML</b> 2 recvs"}, http.StatusOK},
-		{"SendMailNoRecv", SendEmailCaseIn{Receiver: []string{}, Subject: "TestFail", Payload: "<b>HTML</b> payload"}, http.StatusBadRequest},
+		{"SendMailOK", SendEmailCaseIn{Receiver: []string{"yychen@mirrormedia.mg"}, Subject: "RecvTestSuccess", Payload: "<b>HTML</b> payload"}, http.StatusOK},
+		//{"SendMailCC", SendEmailCaseIn{Receiver: []string{"yychen@mirrormedia.mg"}, CC: []string{"cyu2197@gmail.com"}, Subject: "CCTestSuccess", Payload: "<b>HTML</b> payload"}, http.StatusOK},
+		//{"SendMailBCC", SendEmailCaseIn{Receiver: []string{"cyu2197@gmail.com"}, BCC: []string{"yychen@mirrormedia.mg"}, Subject: "BCCTestSuccess", Payload: "<b>HTML</b> payload"}, http.StatusOK},
+		//{"SendMail2RecvOK", SendEmailCaseIn{Receiver: []string{"yychen@mirrormedia.mg"}, Subject: "TestSuccess", Payload: "<b>HTML</b> 2 recvs"}, http.StatusOK},
+		//{"SendMailNoRecv", SendEmailCaseIn{Receiver: []string{}, Subject: "TestFail", Payload: "<b>HTML</b> payload"}, http.StatusBadRequest},
 	}
 
 	for _, testcase := range TestRouteRegisterCases {

--- a/routes/permission.go
+++ b/routes/permission.go
@@ -44,6 +44,7 @@ OuterLoop:
 				continue OuterLoop
 			}
 		}
+		p.Permission = models.NullInt{0, true}
 		result = append(result, p)
 	}
 

--- a/routes/permission_test.go
+++ b/routes/permission_test.go
@@ -79,14 +79,14 @@ var MockPermissionAPI mockPermissionAPI
 func initPermissionTest() {
 
 	var mockDefaultPermissions = []models.Permission{
-		models.Permission{Role: 1, Object: models.NullString{"ChangePW", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"ChangeName", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"CreateAccount", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"AddRole", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"EditRole", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"DeleteRole", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"CreatePost", true}, Permission: 1},
-		models.Permission{Role: 1, Object: models.NullString{"ReadPost", true}, Permission: 1},
+		models.Permission{Role: 1, Object: models.NullString{"ChangePW", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"ChangeName", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"CreateAccount", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"AddRole", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"EditRole", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"DeleteRole", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"CreatePost", true}, Permission: models.NullInt{1, true}},
+		models.Permission{Role: 1, Object: models.NullString{"ReadPost", true}, Permission: models.NullInt{1, true}},
 	}
 
 	err := models.PermissionAPI.InsertPermissions(mockDefaultPermissions)
@@ -210,14 +210,14 @@ func TestPermissionGetAll(t *testing.T) {
 		}
 
 		var mockDefaultPermissions = []models.Permission{
-			models.Permission{Role: 1, Object: models.NullString{"ChangePW", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"ChangeName", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"CreateAccount", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"AddRole", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"EditRole", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"DeleteRole", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"CreatePost", true}, Permission: 1},
-			models.Permission{Role: 1, Object: models.NullString{"ReadPost", true}, Permission: 1},
+			models.Permission{Role: 1, Object: models.NullString{"ChangePW", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"ChangeName", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"CreateAccount", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"AddRole", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"EditRole", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"DeleteRole", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"CreatePost", true}, Permission: models.NullInt{1, true}},
+			models.Permission{Role: 1, Object: models.NullString{"ReadPost", true}, Permission: models.NullInt{1, true}},
 		}
 
 		var result []models.Permission

--- a/routes/project_test.go
+++ b/routes/project_test.go
@@ -67,7 +67,7 @@ func (a *mockProjectAPI) DeleteProjects(p models.Project) error {
 	err := errors.New("Project Not Found")
 	for index, value := range mockProjectDS {
 		if p.ID == value.ID {
-			mockProjectDS[index].Active = 0
+			mockProjectDS[index].Active.Int = 0
 			return nil
 		}
 	}

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -41,20 +41,20 @@ var mockMemberDSBack []models.Member
 var mockMemberDS = []models.Member{
 	models.Member{
 		ID:        "superman@mirrormedia.mg",
-		Active:    1,
+		Active:    models.NullInt{1, true},
 		UpdatedAt: models.NullTime{Time: time.Date(2017, 6, 8, 16, 27, 52, 0, time.UTC), Valid: true},
 		Mail:      models.NullString{String: "superman@mirrormedia.mg", Valid: true},
 	},
 	models.Member{
 		ID:        "test6743",
-		Active:    1,
+		Active:    models.NullInt{1, true},
 		Birthday:  models.NullTime{Time: time.Date(2001, 1, 3, 0, 0, 0, 0, time.UTC), Valid: true},
 		UpdatedAt: models.NullTime{Time: time.Date(2017, 11, 11, 23, 11, 37, 0, time.UTC), Valid: true},
 		Mail:      models.NullString{String: "Lulu_Brakus@yahoo.com", Valid: true},
 	},
 	models.Member{
 		ID:        "Barney.Corwin@hotmail.com",
-		Active:    1,
+		Active:    models.NullInt{1, true},
 		Gender:    models.NullString{String: "M", Valid: true},
 		UpdatedAt: models.NullTime{Time: time.Date(2017, 1, 3, 19, 32, 37, 0, time.UTC), Valid: true},
 		Birthday:  models.NullTime{Time: time.Date(1939, 11, 9, 0, 0, 0, 0, time.UTC), Valid: true},

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -102,9 +102,9 @@ var mockProjectDS = []models.Project{
 		ID:            "32767",
 		Title:         models.NullString{String: "Hello", Valid: true},
 		PostID:        0,
-		LikeAmount:    0,
-		CommentAmount: 0,
-		Active:        1,
+		LikeAmount:    models.NullInt{0, true},
+		CommentAmount: models.NullInt{0, true},
+		Active:        models.NullInt{1, true},
 	},
 }
 


### PR DESCRIPTION
Add nullable int and bool types for models, this change will fix the problem that data overwrote by the default value in the model when performing update operations to DB.
1. Add NullInt and NoolBool type.
2. Apply Nullable types to models: permissions, projects, members.
3. Fix corresponding tests.

4. Provide CC and BCC option for mailing API.