### PR TITLE
Tag API changes and extends

### DIFF
--- a/models/members.go
+++ b/models/members.go
@@ -138,7 +138,6 @@ func (a *memberAPI) GetMembers(req MemberArgs) (result []Member, err error) {
 
 	if len(result) == 0 {
 		result = []Member{}
-		err = errors.New("Members Not Found")
 	}
 
 	return result, err

--- a/models/tags.go
+++ b/models/tags.go
@@ -27,6 +27,7 @@ type TagInterface interface {
 	InsertTag(text string) (int, error)
 	UpdateTag(tag Tag) error
 	UpdatePostTags(postId int, tag_ids []int) error
+	CountTags() (int, error)
 }
 
 type GetTagsArgs struct {
@@ -114,6 +115,14 @@ func (t *tagApi) GetTags(args GetTagsArgs) (tags []Tag, err error) {
 			tags = []Tag{}
 			log.Println(err.Error())
 			return tags, err
+		}
+		if args.ShowStats {
+			if !singleTag.RelatedNews.Valid {
+				singleTag.RelatedNews = NullInt{0, true}
+			}
+			if !singleTag.RelatedReviews.Valid {
+				singleTag.RelatedReviews = NullInt{0, true}
+			}
 		}
 		tags = append(tags, singleTag)
 	}
@@ -207,7 +216,16 @@ func (t *tagApi) UpdatePostTags(post_id int, tag_ids []int) error {
 	tx.Commit()
 
 	return nil
+}
 
+func (a *tagApi) CountTags() (result int, err error) {
+
+	err = DB.Get(&result, `SELECT COUNT(*) FROM tags`)
+	if err != nil {
+		return 0, err
+	}
+
+	return result, err
 }
 
 var TagStatus map[string]interface{}

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -98,7 +98,7 @@ func (r *followingHandler) GetByUser(c *gin.Context) {
 	if err != nil {
 		switch err.Error() {
 		case "Not Found":
-			c.JSON(http.StatusNotFound, make([]string, 0))
+			c.JSON(http.StatusOK, make([]string, 0))
 			return
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": "Internal Server Error"})

--- a/routes/follow_test.go
+++ b/routes/follow_test.go
@@ -117,7 +117,7 @@ func (a *mockFollowingAPI) GetFollowing(params map[string]string) (interface{}, 
 		}, nil
 	case params["resource"] == "post":
 		return []models.Post{
-			models.Post{ID: 42, Active: models.NullInt{1, true}},
+			models.Post{ID: 42, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}},
 		}, nil
 	case params["resource"] == "project":
 		return []models.Project{
@@ -177,10 +177,10 @@ func TestFollowingGet(t *testing.T) {
 		in   CaseIn
 		out  CaseOut
 	}{
-		{"GetFollowingPostOK", CaseIn{"post", "followtest1@mirrormedia.mg"}, CaseOut{http.StatusOK, `[{"id":42,"author":null,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":null,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":null,"updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null}]`}},
+		{"GetFollowingPostOK", CaseIn{"post", "followtest1@mirrormedia.mg"}, CaseOut{http.StatusOK, `[{"id":42,"author":null,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":0,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":null,"updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null}]`}},
 		{"GetFollowingMemberOK", CaseIn{"member", "followtest1@mirrormedia.mg"}, CaseOut{http.StatusOK, `[{"id":"followtest2@mirrormedia.mg","name":null,"nickname":null,"birthday":null,"gender":null,"work":null,"mail":null,"register_mode":null,"social_id":null,"talk_id":null,"created_at":null,"updated_at":null,"updated_by":null,"description":null,"profile_image":null,"identity":null,"role":null,"active":1,"custom_editor":null,"hide_profile":null,"profile_push":null,"post_push":null,"comment_push":null}]`}},
 		{"GetFollowingProjectOK", CaseIn{"project", "followtest1@mirrormedia.mg"}, CaseOut{http.StatusOK, `[{"id":420,"created_at":null,"updated_at":null,"updated_by":null,"published_at":null,"post_id":42,"like_amount":null,"comment_amount":null,"active":1,"hero_image":null,"title":null,"description":null,"author":null,"og_title":null,"og_description":null,"og_image":null,"order":null}]`}},
-		{"GetFollowingFollowerNotExist", CaseIn{"project", "unknown@user.who"}, CaseOut{http.StatusNotFound, `[]`}},
+		{"GetFollowingFollowerNotExist", CaseIn{"project", "unknown@user.who"}, CaseOut{http.StatusOK, `[]`}},
 	}
 
 	for _, testcase := range TestFollowingGetCases {
@@ -258,12 +258,12 @@ func TestFollowedGet(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		if w.Code != testcase.out.httpcode {
-			t.Errorf("Want %d but get %d, testcase %s", testcase.out.httpcode, w.Code, testcase.name)
+			t.Errorf("Want %d but get %d, testcase %s", w.Code, testcase.out.httpcode, testcase.name)
 			t.Fail()
 		}
 
 		if w.Body.String() != testcase.out.resp {
-			t.Errorf("Expect get error message %v but get %v, testcase %s", testcase.out.resp, w.Body.String(), testcase.name)
+			t.Errorf("Expect get error message %v but get %v, testcase %s", w.Body.String(), testcase.out.resp, testcase.name)
 			t.Fail()
 		}
 

--- a/routes/member.go
+++ b/routes/member.go
@@ -62,9 +62,11 @@ func (r *memberHandler) GetAll(c *gin.Context) {
 	result, err := models.MemberAPI.GetMembers(params)
 	if err != nil {
 		switch err.Error() {
-		case "Members Not Found":
-			c.JSON(http.StatusNotFound, gin.H{"Error": "Members Not Found"})
-			return
+		/*
+			case "Members Not Found":
+				c.JSON(http.StatusNotFound, gin.H{"Error": "Members Not Found"})
+				return
+		*/
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return

--- a/routes/member_test.go
+++ b/routes/member_test.go
@@ -38,7 +38,7 @@ func (a *mockMemberAPI) GetMembers(req models.MemberArgs) (result []models.Membe
 		if k == "$nin" && reflect.DeepEqual(v, []int{0, -1}) {
 			return []models.Member{mockMemberDS[0]}, nil
 		} else if k == "$nin" && reflect.DeepEqual(v, []int{-1, 0, 1}) {
-			return []models.Member{}, errors.New("Members Not Found")
+			return []models.Member{}, nil
 		} else if reflect.DeepEqual(v, []int{-3, 0, 1}) {
 			return []models.Member{}, errors.New("Not all active elements are valid")
 		} else if reflect.DeepEqual(v, []int{3, 4}) {
@@ -207,7 +207,7 @@ func TestRouteGetMembers(t *testing.T) {
 			[]models.Member{mockMemberDS[0]}}},
 		{"NotFound", `/members?active={"$nin":[-1,0,1]}`,
 			ExpectGetsResp{ExpectResp{
-				http.StatusNotFound, `{"Error":"Members Not Found"}`},
+				http.StatusOK, ``},
 				[]models.Member{}}},
 		{"MoreThanOneActive", `/members?active={"$nin":[1,0], "$in":[-1,3]}`,
 			ExpectGetsResp{

--- a/routes/post.go
+++ b/routes/post.go
@@ -67,9 +67,11 @@ func (r *postHandler) GetAll(c *gin.Context) {
 	result, err := models.PostAPI.GetPosts(params)
 	if err != nil {
 		switch err.Error() {
-		case "Posts Not Found":
-			c.JSON(http.StatusNotFound, gin.H{"Error": "Posts Not Found"})
-			return
+		/*
+			case "Posts Not Found":
+				c.JSON(http.StatusNotFound, gin.H{"Error": "Posts Not Found"})
+				return
+		*/
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": "Internal Server Error"})
 			return

--- a/routes/post_test.go
+++ b/routes/post_test.go
@@ -88,7 +88,6 @@ func (a *mockPostAPI) GetPosts(args models.PostArgs) (result []models.PostMember
 				for oauthor, vauthor := range args["posts.author"].(map[string][]string) {
 					if oauthor == "$in" && reflect.DeepEqual(vauthor, []string{"flash@flash.com"}) {
 						result = []models.PostMember{}
-						err = errors.New("Posts Not Found")
 					}
 				}
 			}
@@ -316,7 +315,7 @@ func TestRouteGetPosts(t *testing.T) {
 				{Post: mockPostDS[1], Member: mockMemberDS[1], UpdatedBy: models.UpdatedBy{}},
 				{Post: mockPostDS[3], Member: models.Member{}, UpdatedBy: models.UpdatedBy{}},
 			}}},
-		{"NotFound", `/posts?author={"$in":["flash@flash.com"]}&active={"$nin":[1,4]}`, ExpectGetsResp{ExpectResp{http.StatusNotFound, `{"Error":"Posts Not Found"}`},
+		{"NotFound", `/posts?author={"$in":["flash@flash.com"]}&active={"$nin":[1,4]}`, ExpectGetsResp{ExpectResp{http.StatusOK, ``},
 			[]models.PostMember{}}},
 	}
 	for _, tc := range testPostsGetCases {
@@ -329,7 +328,7 @@ func TestRouteGetPosts(t *testing.T) {
 				t.Errorf("%s Want %d but get %d", tc.name, tc.expect.httpcode, w.Code)
 			}
 			if w.Code != http.StatusOK && w.Body.String() != tc.expect.err {
-				t.Errorf("%s expect to get error message %v but get %v", tc.name, w.Body.String(), tc.expect.err)
+				t.Errorf("%s expect to get error message %v but get %v", tc.name, tc.expect.err, w.Body.String())
 			}
 			expected, _ := json.Marshal(map[string][]models.PostMember{"_items": tc.expect.resp})
 			if w.Code == http.StatusOK && w.Body.String() != string(expected) {
@@ -358,7 +357,7 @@ func TestRouteGetPost(t *testing.T) {
 					Post:      mockPostDS[0],
 					Member:    mockMemberDS[0],
 					UpdatedBy: models.UpdatedBy(mockMemberDS[0])},
-				Tags: ""}}},
+				Tags: models.NullString{}}}},
 		{"NotExisted", "/post/3", ExpectGetResp{ExpectResp{http.StatusNotFound, `{"Error":"Post Not Found"}`}, models.TaggedPostMember{}}},
 	}
 	for _, tc := range testPostGetCases {
@@ -371,7 +370,7 @@ func TestRouteGetPost(t *testing.T) {
 				t.Errorf("%s Want %d but get %d", tc.name, tc.expect.httpcode, w.Code)
 			}
 			if w.Code != http.StatusOK && w.Body.String() != tc.expect.err {
-				t.Errorf("%s expect to get error message %v but get %v", tc.name, w.Body.String(), tc.expect.err)
+				t.Errorf("%s expect to get error message %v but get %v", tc.name, tc.expect.err, w.Body.String())
 			}
 
 			// expected, _ := json.Marshal(tc.expect.resp)

--- a/routes/tag.go
+++ b/routes/tag.go
@@ -105,6 +105,16 @@ func (r *tagHandler) Delete(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+func (r *tagHandler) Count(c *gin.Context) {
+	count, err := models.TagAPI.CountTags()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	resp := map[string]int{"total": count}
+	c.JSON(http.StatusOK, gin.H{"_meta": resp})
+}
+
 func (r *tagHandler) SetRoutes(router *gin.Engine) {
 
 	tagRouter := router.Group("/tags")
@@ -113,6 +123,8 @@ func (r *tagHandler) SetRoutes(router *gin.Engine) {
 		tagRouter.POST("", r.Post)
 		tagRouter.PUT("", r.Put)
 		tagRouter.DELETE("", r.Delete)
+
+		tagRouter.GET("/count", r.Count)
 	}
 }
 

--- a/routes/tag_test.go
+++ b/routes/tag_test.go
@@ -89,6 +89,10 @@ func (t *mockTagAPI) UpdatePostTags(postId int, tag_ids []int) error {
 	return nil
 }
 
+func (t *mockTagAPI) CountTags() (int, error) {
+	return len(mockTagDS), nil
+}
+
 func TestRouteTags(t *testing.T) {
 
 	tags := []models.Tag{
@@ -220,6 +224,14 @@ func TestRouteTags(t *testing.T) {
 	t.Run("DaleteTags", func(t *testing.T) {
 		testcases := []genericTestcase{
 			genericTestcase{"DeleteTagOK", "DELETE", "/tags?ids=[1, 2, 3, 4]", ``, http.StatusOK, ``},
+		}
+		for _, tc := range testcases {
+			genericDoTest(tc, t, asserter)
+		}
+	})
+	t.Run("CountTags", func(t *testing.T) {
+		testcases := []genericTestcase{
+			genericTestcase{"CountTagsOK", "GET", "/tags/count", ``, http.StatusOK, `{"_meta":{"total":5}}`},
 		}
 		for _, tc := range testcases {
 			genericDoTest(tc, t, asserter)

--- a/routes/tag_test.go
+++ b/routes/tag_test.go
@@ -106,10 +106,19 @@ func TestRouteTags(t *testing.T) {
 	}
 
 	for _, params := range []models.Post{
-		models.Post{ID: 43, Active: models.NullInt{1, true}, Type: models.NullInt{1, true}},
-		models.Post{ID: 44, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}},
+		models.Post{ID: 43, Active: models.NullInt{1, true}, Type: models.NullInt{1, true}, Author: models.NullString{"AMI@mirrormedia.mg", true}, UpdatedBy: models.NullString{"AMI@mirrormedia.mg", true}},
+		models.Post{ID: 44, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}, Author: models.NullString{"AMI@mirrormedia.mg", true}, UpdatedBy: models.NullString{"AMI@mirrormedia.mg", true}},
 	} {
 		_, err := models.PostAPI.InsertPost(params)
+		if err != nil {
+			log.Printf("Insert post fail when init test case. Error: %v", err)
+		}
+	}
+
+	for _, params := range []models.Member{
+		models.Member{ID: "AMI@mirrormedia.mg", Active: models.NullInt{1, true}},
+	} {
+		err := models.MemberAPI.InsertMember(params)
 		if err != nil {
 			log.Printf("Insert post fail when init test case. Error: %v", err)
 		}
@@ -122,8 +131,9 @@ func TestRouteTags(t *testing.T) {
 		{43, []int{1, 2}},
 		{44, []int{1, 3}},
 	} {
-		err := models.TagAPI.UpdatePostTags(params.post_id, params.tag_ids)
-		log.Printf("Insert post tag fail when init test case. Error: %v", err)
+		if err := models.TagAPI.UpdatePostTags(params.post_id, params.tag_ids); err != nil {
+			log.Printf("Insert post tag fail when init test case. Error: %v", err)
+		}
 	}
 
 	asserter := func(resp string, tc genericTestcase, t *testing.T) {
@@ -215,4 +225,14 @@ func TestRouteTags(t *testing.T) {
 			genericDoTest(tc, t, asserter)
 		}
 	})
+	/*
+		t.Run("GetPostWithTags", func(t *testing.T) {
+			testcases := []genericTestcase{
+				genericTestcase{"GetPostWithTagsOK", "GET", "/post/43", ``, http.StatusOK, `{"_items":[{"tags":[{"id":"1","text":"text5566"},{"id":"2","text":"tag2"}],"id":43,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":1,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"author":{"id":"AMI@mirrormedia.mg","name":null,"nickname":null,"birthday":null,"gender":null,"work":null,"mail":null,"register_mode":null,"social_id":null,"talk_id":null,"created_at":null,"updated_at":null,"updated_by":null,"description":null,"profile_image":null,"identity":null,"role":null,"active":1,"custom_editor":null,"hide_profile":null,"profile_push":null,"post_push":null,"comment_push":null},"updated_by":{"id":"AMI@mirrormedia.mg","name":null,"nickname":null,"birthday":null,"gender":null,"work":null,"mail":null,"register_mode":null,"social_id":null,"talk_id":null,"created_at":null,"updated_at":null,"updated_by":null,"description":null,"profile_image":null,"identity":null,"role":null,"active":1,"custom_editor":null,"hide_profile":null,"profile_push":null,"post_push":null,"comment_push":null}}]}`},
+			}
+			for _, tc := range testcases {
+				genericDoTest(tc, t, asserter)
+			}
+		})
+	*/
 }


### PR DESCRIPTION
Several API changes, mostly tag API
1. New API: Get tag total counts, same as posts/count
2. Change API spec: return 200 and empty result set when getting list and not found
3. Change API spec: return tag name and tag id in "tags" field when getting single post
4. Bugfix: set default related_comment and related_news value = 0 when getting tags with stats