### PR TITLE
New get following API and other improvements

### DIFF
--- a/routes/follow.go
+++ b/routes/follow.go
@@ -146,12 +146,36 @@ func (r *followingHandler) GetByResource(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+func (r *followingHandler) GetFollowMap(c *gin.Context) {
+	var input models.GetFollowMapArgs
+	err := c.ShouldBindJSON(&input)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": "Bad Parameter Format"})
+		return
+	}
+
+	result, err := models.FollowingAPI.GetFollowMap(input)
+
+	if err != nil {
+		switch err.Error() {
+		case "Resource Not Supported":
+			c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+			return
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"Error": "Internal Server Error"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
 func (r *followingHandler) SetRoutes(router *gin.Engine) {
 	followRouter := router.Group("following")
 	{
 		followRouter.GET("/byuser", r.GetByUser)
 		followRouter.GET("/byresource", r.GetByResource)
-		//followRouter.GET("/updated", r.GetListByResource)
+		followRouter.GET("/map", r.GetFollowMap)
 	}
 
 	router.POST("/restful/pubsub", r.Push)

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -87,12 +87,14 @@ func (r *followingHandler) GetByUser(c *gin.Context) {
 	input := struct {
 		MemberId string `json:"subject"`
 		Resource string `json:"resource"`
+		Type     string `json:"resource_type,omitempty"`
 	}{}
 	c.ShouldBindJSON(&input)
 
 	result, err := models.FollowingAPI.GetFollowing(map[string]string{
-		"subject":  input.MemberId,
-		"resource": input.Resource,
+		"subject":       input.MemberId,
+		"resource":      input.Resource,
+		"resource_type": input.Type,
 	})
 
 	if err != nil {
@@ -110,10 +112,7 @@ func (r *followingHandler) GetByUser(c *gin.Context) {
 }
 
 func (r *followingHandler) GetByResource(c *gin.Context) {
-	input := struct {
-		Resource string   `json:"resource"`
-		Ids      []string `json:"ids"`
-	}{}
+	var input models.GetFollowedArgs
 	c.ShouldBindJSON(&input)
 
 	if len(input.Ids) == 0 {
@@ -137,7 +136,7 @@ func (r *followingHandler) GetByResource(c *gin.Context) {
 		return
 	}
 
-	result, err := models.FollowingAPI.GetFollowed(input.Resource, input.Ids)
+	result, err := models.FollowingAPI.GetFollowed(input)
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"Error": "Internal Server Error"})
@@ -152,6 +151,7 @@ func (r *followingHandler) SetRoutes(router *gin.Engine) {
 	{
 		followRouter.GET("/byuser", r.GetByUser)
 		followRouter.GET("/byresource", r.GetByResource)
+		//followRouter.GET("/updated", r.GetListByResource)
 	}
 
 	router.POST("/restful/pubsub", r.Push)

--- a/routes/tag.go
+++ b/routes/tag.go
@@ -155,7 +155,7 @@ func (r *tagHandler) SetRoutes(router *gin.Engine) {
 }
 
 func validateSorting(s string) bool {
-	if matched, err := regexp.MatchString("-?(updated_at|created_at|tag_id|related_reviews|related_news)", s); err != nil || !matched {
+	if matched, err := regexp.MatchString("-?(text|updated_at|created_at|related_reviews|related_news)", s); err != nil || !matched {
 		return false
 	}
 	return true


### PR DESCRIPTION
1. New API: get following map, this returns the mapping of the following resource IDs for each user with the constraint of resource type and last update time.
2. Following Post APIs now accept a new parameter: "resource_type", specifying the post type affected by the APIs.