### PR TITLE
Released API for query member with nickname keyword

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 	models.ProjectPublishStatus = viper.GetStringMap("models.projects_publish_status")
 	models.TagStatus = viper.GetStringMap("models.tags")
 
+	// waiting: allow full utf8 support by incorporating `?charset=utf8mb4` in connection
 	dbURI := fmt.Sprintf("%s:%s@tcp(%s)/memberdb?parseTime=true", sqlUser, sqlPass, fmt.Sprintf("%s:%v", sqlHost, sqlPort))
 
 	// Start with default middleware

--- a/models/posts.go
+++ b/models/posts.go
@@ -100,6 +100,7 @@ func (t *TaggedPostMember) MarshalJSON() ([]byte, error) {
 // in the usage of anonymous struct in PostMember
 type MemberBasic struct {
 	ID           string     `json:"id" db:"member_id"`
+	UUID         NullString `json:"uuid" db:"uuid"`
 	Nickname     NullString `json:"nickname" db:"nickname"`
 	ProfileImage NullString `json:"profile_image" db:"profile_image"`
 	Description  NullString `json:"description" db:"description"`

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -147,6 +147,8 @@ var mockMemberDSBack []models.Member
 var mockMemberDS = []models.Member{
 	models.Member{
 		ID:           "superman@mirrormedia.mg",
+		UUID:         "3d64e480-3e30-11e8-b94b-cfe922eb374f",
+		Nickname:     models.NullString{String: "readr", Valid: true},
 		Active:       models.NullInt{Int: 1, Valid: true},
 		UpdatedAt:    models.NullTime{Time: time.Date(2017, 6, 8, 16, 27, 52, 0, time.UTC), Valid: true},
 		Mail:         models.NullString{String: "superman@mirrormedia.mg", Valid: true},
@@ -155,6 +157,8 @@ var mockMemberDS = []models.Member{
 	},
 	models.Member{
 		ID:        "test6743",
+		UUID:      "3d651126-3e30-11e8-b94b-cfe922eb374f",
+		Nickname:  models.NullString{String: "yeahyeahyeah", Valid: true},
 		Active:    models.NullInt{Int: 0, Valid: true},
 		Birthday:  models.NullTime{Time: time.Date(2001, 1, 3, 0, 0, 0, 0, time.UTC), Valid: true},
 		UpdatedAt: models.NullTime{Time: time.Date(2017, 11, 11, 23, 11, 37, 0, time.UTC), Valid: true},
@@ -163,6 +167,8 @@ var mockMemberDS = []models.Member{
 	},
 	models.Member{
 		ID:        "Barney.Corwin@hotmail.com",
+		UUID:      "3d6512e8-3e30-11e8-b94b-cfe922eb374f",
+		Nickname:  models.NullString{String: "reader", Valid: true},
 		Active:    models.NullInt{Int: -1, Valid: true},
 		Gender:    models.NullString{String: "M", Valid: true},
 		UpdatedAt: models.NullTime{Time: time.Date(2017, 1, 3, 19, 32, 37, 0, time.UTC), Valid: true},


### PR DESCRIPTION
1. Added new return field uuid in embedded author/updatedBy for Posts
2. Allowed search member uuid with nickname keyword

use `/members/nickname?keyword=[KEYWORD]` 

it will return uuid&nickname