### PR TITLE
Points API modified and database migration

### DIFF
--- a/db_schema/5_points_add_balance_down.sql
+++ b/db_schema/5_points_add_balance_down.sql
@@ -1,0 +1,2 @@
+-- Drop points column total --
+AlTER TABLE points DROP COLUMN balance;

--- a/db_schema/5_points_add_balance_up.sql
+++ b/db_schema/5_points_add_balance_up.sql
@@ -1,0 +1,2 @@
+-- add column total in points --
+ALTER TABLE points ADD COLUMN balance INT NOT NULL DEFAULT 0;

--- a/routes/points.go
+++ b/routes/points.go
@@ -44,12 +44,18 @@ func (r *pointsHandler) bindQuery(c *gin.Context, args *models.PointsArgs) (err 
 			return err
 		}
 	}
-	return nil
+	err = c.ShouldBindQuery(args)
+	return err
 }
 
 func (r *pointsHandler) Get(c *gin.Context) {
 
 	var args = &models.PointsArgs{}
+	args.Set(map[string]interface{}{
+		"max_result": 100,
+		"page":       1,
+		"sort":       "-created_at",
+	})
 	if err := r.bindQuery(c, args); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return
@@ -70,6 +76,9 @@ func (r *pointsHandler) Post(c *gin.Context) {
 	}
 	if !pts.CreatedAt.Valid {
 		pts.CreatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+	if !pts.UpdatedAt.Valid {
+		pts.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
 	}
 	p, err := models.PointsAPI.Insert(pts)
 	if err != nil {


### PR DESCRIPTION
1. Database included balance to record balance for each transaction

source `5_points_add_balance_up.sql` for forward migration.

2. Points support usage for max_result, page, and sort

The usage is the same as `/members` or `/posts`:

GET `/points/1/2?max_result=10&page=1&sort=-updated_at` will return max 10 points transaction results per page, first page, and sorted in descending order for member with id 1, object type 2.

The default max_result is `100`, page is `1`, sort is `-created_at`

3. Set default updated_at when POST
4. Used points in table Members as base to update new balance

balance in new `Points` record = points in `Members` - points in new `Points` record