### PR TITLE
Pubsub API adjustment

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ func main() {
 	routes.PointsHandler.SetRoutes(router)
 	routes.PostHandler.SetRoutes(router)
 	routes.ProjectHandler.SetRoutes(router)
+	routes.PubsubHandler.SetRoutes(router)
 	routes.ReportHandler.SetRoutes(router)
 	routes.TagHandler.SetRoutes(router)
 

--- a/routes/comment.go
+++ b/routes/comment.go
@@ -279,10 +279,6 @@ func (r *commentsHandler) SetRoutes(router *gin.Engine) {
 	commentsRouter := router.Group("/comment")
 	{
 		commentsRouter.GET("", r.GetComments)
-		commentsRouter.POST("", r.PostComment)
-		commentsRouter.PUT("", r.PutComment)
-		commentsRouter.PUT("/status", r.PutCommentStatus)
-		commentsRouter.DELETE("", r.DeleteComment)
 	}
 	reportcommentsRouter := router.Group("/reported_comment")
 	{

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -1,86 +1,15 @@
 package routes
 
 import (
-	"log"
 	"strconv"
 
-	"encoding/json"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/readr-media/readr-restful/models"
 )
 
-var supportedAction = map[string]bool{
-	"follow":   true,
-	"unfollow": true,
-}
-
-type PubsubMessageStruct struct {
-	Subscription string `json:"subscription"`
-	Message      struct {
-		ID   string   `json:"messageId"`
-		Attr []string `json:"attributes"`
-		Body []byte   `json:"data"`
-	}
-}
-
-type PubsubMessageBody struct {
-	Resource string `json:"resource"`
-	Action   string `json:"action"`
-	Subject  string `json:"subject"`
-	Object   string `json:"object"`
-}
-
 type followingHandler struct{}
-
-func (r *followingHandler) Push(c *gin.Context) {
-	var input PubsubMessageStruct
-	c.ShouldBindJSON(&input)
-
-	var body PubsubMessageBody
-	err := json.Unmarshal(input.Message.Body, &body)
-	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
-		return
-	}
-
-	switch body.Action {
-	case "follow", "unfollow":
-		object, err := strconv.Atoi(body.Object)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
-			return
-		}
-		subject, err := strconv.Atoi(body.Subject)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
-			return
-		}
-
-		params := models.FollowArgs{Resource: body.Resource, Subject: int64(subject), Object: int64(object)}
-
-		switch body.Action {
-		case "follow":
-			if err = models.FollowingAPI.AddFollowing(params); err != nil {
-				log.Printf("%s fail: %v \n", body.Action, err.Error())
-				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
-				return
-			}
-			c.Status(http.StatusOK)
-		case "unfollow":
-			if err = models.FollowingAPI.DeleteFollowing(params); err != nil {
-				log.Printf("%s fail: %v \n", body.Action, err.Error())
-				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
-				return
-			}
-			c.Status(http.StatusOK)
-		}
-	default:
-		c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
-		return
-	}
-}
 
 func (r *followingHandler) GetByUser(c *gin.Context) {
 	var input models.GetFollowingArgs
@@ -169,8 +98,6 @@ func (r *followingHandler) SetRoutes(router *gin.Engine) {
 		followRouter.GET("/byresource", r.GetByResource)
 		followRouter.GET("/map", r.GetFollowMap)
 	}
-
-	router.POST("/restful/pubsub", r.Push)
 }
 
 var FollowingHandler followingHandler

--- a/routes/follow_test.go
+++ b/routes/follow_test.go
@@ -405,9 +405,9 @@ func TestFollowMap(t *testing.T) {
 func TestFollowingAddDelete(t *testing.T) {
 
 	type PubsubWrapperMessage struct {
-		ID   string   `json:"messageId"`
-		Attr []string `json:"attributes"`
-		Body []byte   `json:"data"`
+		ID   string            `json:"messageId"`
+		Attr map[string]string `json:"attributes"`
+		Body []byte            `json:"data"`
 	}
 
 	type PubsubWrapper struct {
@@ -453,7 +453,7 @@ func TestFollowingAddDelete(t *testing.T) {
 			t.Fail()
 		}
 
-		jsonStr, err := json.Marshal(&PubsubWrapper{"subs", PubsubWrapperMessage{"1", []string{"1"}, bodyJsonStr}})
+		jsonStr, err := json.Marshal(&PubsubWrapper{"subs", PubsubWrapperMessage{"1", map[string]string{"type": "follow", "action": testcase.in.Action}, bodyJsonStr}})
 		if err != nil {
 			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
 			t.Fail()

--- a/routes/pubsub.go
+++ b/routes/pubsub.go
@@ -1,0 +1,196 @@
+package routes
+
+import (
+	"log"
+	"strconv"
+	"time"
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/readr-media/readr-restful/models"
+)
+
+var supportedAction = map[string]bool{
+	"follow":         true,
+	"unfollow":       true,
+	"post_comment":   true,
+	"edit_comment":   true,
+	"delete_comment": true,
+}
+
+type PubsubMessageMetaBody struct {
+	ID   string            `json:"messageId"`
+	Body []byte            `json:"data"`
+	Attr map[string]string `json:"attributes"`
+}
+
+type PubsubMessageMeta struct {
+	Subscription string `json:"subscription"`
+	Message      PubsubMessageMetaBody
+}
+
+type PubsubFollowMsgBody struct {
+	Resource string `json:"resource"`
+	Action   string `json:"action"`
+	Subject  string `json:"subject"`
+	Object   string `json:"object"`
+}
+
+type pubsubHandler struct{}
+
+func (r *pubsubHandler) Push(c *gin.Context) {
+	var input PubsubMessageMeta
+	c.ShouldBindJSON(&input)
+
+	msgType := input.Message.Attr["type"]
+	actionType := input.Message.Attr["action"]
+
+	switch msgType {
+	case "follow":
+
+		var body PubsubFollowMsgBody
+
+		err := json.Unmarshal(input.Message.Body, &body)
+		if err != nil {
+			log.Printf("Parse msg body fail: %v \n", err.Error())
+			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
+			return
+		}
+
+		object, err := strconv.Atoi(body.Object)
+		if err != nil {
+			log.Printf("%s fail: %v \n", actionType, err.Error())
+			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
+			return
+		}
+		subject, err := strconv.Atoi(body.Subject)
+		if err != nil {
+			log.Printf("%s fail: %v \n", actionType, err.Error())
+			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
+			return
+		}
+
+		params := models.FollowArgs{Resource: body.Resource, Subject: int64(subject), Object: int64(object)}
+
+		switch actionType {
+		case "follow":
+			if err = models.FollowingAPI.AddFollowing(params); err != nil {
+				log.Printf("%s fail: %v \n", actionType, err.Error())
+				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
+				return
+			}
+			c.Status(http.StatusOK)
+		case "unfollow":
+			if err = models.FollowingAPI.DeleteFollowing(params); err != nil {
+				log.Printf("%s fail: %v \n", actionType, err.Error())
+				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
+				return
+			}
+		default:
+			log.Println("Action Type Not Support", actionType)
+			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
+		}
+	case "comment":
+		switch actionType {
+
+		case "post":
+			comment := models.Comment{}
+			err := json.Unmarshal(input.Message.Body, &comment)
+			if err != nil {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				c.Status(http.StatusOK)
+				return
+			}
+
+			if !comment.Body.Valid || !comment.Author.Valid || !comment.Resource.Valid {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, "Missing Required Parameters")
+				c.JSON(http.StatusOK, gin.H{"Error": "Missing Required Parameters"})
+				return
+			}
+
+			comment.CreatedAt = models.NullTime{Time: time.Now(), Valid: true}
+			comment.Active = models.NullInt{Int: int64(models.CommentActive["active"].(float64)), Valid: true}
+			comment.Status = models.NullInt{Int: int64(models.CommentStatus["show"].(float64)), Valid: true}
+
+			_, err = models.CommentAPI.InsertComment(comment)
+			if err != nil {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				c.Status(http.StatusOK)
+				return
+			}
+			c.Status(http.StatusOK)
+
+		case "put":
+			comment := models.Comment{}
+			err := json.Unmarshal(input.Message.Body, &comment)
+			if err != nil {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				c.Status(http.StatusOK)
+				return
+			}
+
+			if comment.ID == 0 || comment.ParentID.Valid || comment.Resource.Valid || comment.CreatedAt.Valid || comment.Author.Valid {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, "Invalid Parameters")
+				c.JSON(http.StatusOK, gin.H{"Error": "Invalid Parameters"})
+				return
+			}
+
+			comment.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
+
+			err = models.CommentAPI.UpdateComment(comment)
+			if err != nil {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+			}
+			c.Status(http.StatusOK)
+
+		case "putstatus", "delete":
+			args := models.CommentUpdateArgs{}
+			err := json.Unmarshal(input.Message.Body, &args)
+			if err != nil {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				c.Status(http.StatusOK)
+				return
+			}
+
+			if len(args.IDs) == 0 {
+				log.Printf("%s %s fail: %v \n", msgType, actionType, "ID List Empty")
+				c.JSON(http.StatusOK, gin.H{"Error": "ID List Empty"})
+				return
+			}
+
+			if actionType == "delete" {
+				args = models.CommentUpdateArgs{
+					IDs:       args.IDs,
+					UpdatedAt: models.NullTime{Time: time.Now(), Valid: true},
+					Active:    models.NullInt{int64(models.CommentActive["deactive"].(float64)), true},
+				}
+			} else {
+				args.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
+			}
+
+			err = models.CommentAPI.UpdateComments(args)
+			if err != nil {
+				switch err.Error() {
+				case "Posts Not Found":
+					log.Printf("%s %s fail: %v \n", msgType, actionType, "Comments Not Found")
+				default:
+					log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				}
+			}
+			c.Status(http.StatusOK)
+		}
+
+	default:
+		log.Println("Pubsub Message Type Not Support", actionType)
+		c.Status(http.StatusOK)
+		return
+	}
+}
+
+func (r *pubsubHandler) SetRoutes(router *gin.Engine) {
+	router.POST("/restful/pubsub", r.Push)
+}
+
+var PubsubHandler pubsubHandler

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -77,6 +77,7 @@ func TestMain(m *testing.M) {
 	PointsHandler.SetRoutes(r)
 	PostHandler.SetRoutes(r)
 	ProjectHandler.SetRoutes(r)
+	PubsubHandler.SetRoutes(r)
 	ReportHandler.SetRoutes(r)
 	TagHandler.SetRoutes(r)
 


### PR DESCRIPTION
1. Change request method for inseting/updating/deleting comment to gcp pub/sub.
2. Change rules for gcp Pubsub push endpoint to receive several kinds of API requests.