### PR TITLE
Memo changes: Provided abstract content for member not paid and isPaid parameter in project object

### DIFF
--- a/models/comments.go
+++ b/models/comments.go
@@ -630,8 +630,7 @@ func (c *commentAPI) generateCommentNotifications(id int) (err error) {
 
 	case "memo":
 		res_id, _ := strconv.Atoi(r_id)
-		// Default to get abstract content
-		memo, err := MemoAPI.GetMemo(res_id, 20, 0)
+		memo, err := MemoAPI.GetMemo(res_id)
 		if err != nil {
 			log.Println("Error get post", r_id, err.Error())
 		}

--- a/models/comments.go
+++ b/models/comments.go
@@ -630,7 +630,8 @@ func (c *commentAPI) generateCommentNotifications(id int) (err error) {
 
 	case "memo":
 		res_id, _ := strconv.Atoi(r_id)
-		memo, err := MemoAPI.GetMemo(res_id)
+		// Default to get abstract content
+		memo, err := MemoAPI.GetMemo(res_id, 20, 0)
 		if err != nil {
 			log.Println("Error get post", r_id, err.Error())
 		}

--- a/models/db.go
+++ b/models/db.go
@@ -68,6 +68,21 @@ func makeFieldString(mode string, pattern string, tags []string) (result []strin
 		for _, value := range tags {
 			result = append(result, fmt.Sprintf(pattern, value, value))
 		}
+	/*
+		Case "general" is created for all use scenerio
+		Just pass in pattern string and all the tags we want to format,
+		it could automatically generate corresponding amount of single tag according to counts of %s in pattern.
+		It could be used to replace both case "get" and "update".
+		We could take down mode argument and other switch cases for future refactor of makeFieldString.
+	*/
+	case "general":
+		for _, field := range tags {
+			fields := make([]interface{}, strings.Count(pattern, "%s"))
+			for i := range fields {
+				fields[i] = field
+			}
+			result = append(result, fmt.Sprintf(pattern, fields...))
+		}
 	}
 	return result
 }

--- a/models/memos.go
+++ b/models/memos.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
 	"strings"
 
@@ -54,6 +55,7 @@ type MemoGetArgs struct {
 	ProjectPublishStatus map[string][]int `form:"project_publish_status"`
 	MemberID             int64            `form:"member_id"`
 	AbstractLength       int64            `form:"abstract_length"`
+	MemoID               int64
 }
 
 func (p *MemoGetArgs) Default() (result *MemoGetArgs) {
@@ -71,9 +73,9 @@ func (p *MemoGetArgs) Validate() bool {
 func (p *MemoGetArgs) parse() (restricts string, values []interface{}) {
 	where := make([]string, 0)
 
-	if p.MemoPublishStatus == nil && p.ProjectPublishStatus == nil && p.Active == nil && len(p.Author) == 0 && len(p.Project) == 0 {
-		return "", nil
-	}
+	// if p.MemoPublishStatus == nil && p.ProjectPublishStatus == nil && p.Active == nil && len(p.Author) == 0 && len(p.Project) == 0 {
+	// 	return "", nil
+	// }
 
 	if p.Active != nil {
 		for k, v := range p.Active {
@@ -107,6 +109,12 @@ func (p *MemoGetArgs) parse() (restricts string, values []interface{}) {
 		where = append(where, fmt.Sprintf("%s IN (?)", "project.slug"))
 		values = append(values, p.Slugs)
 	}
+
+	if p.MemoID != 0 {
+		where = append(where, fmt.Sprintf("%s = ?", "memos.memo_id"))
+		values = append(values, p.MemoID)
+	}
+
 	if len(where) > 1 {
 		restricts = fmt.Sprintf(" WHERE %s", strings.Join(where, " AND "))
 	} else if len(where) == 1 {
@@ -174,8 +182,12 @@ func (p *MemoUpdateArgs) parse() (updates string, values []interface{}) {
 
 type MemoDetail struct {
 	Memo
-	Authors Member  `json:"author" db:"author"`
-	Project Project `json:"project" db:"project"`
+	Authors Member `json:"author" db:"author"`
+	// Project Project `json:"project" db:"project"`
+	Project struct {
+		Project
+		Paid bool `json:"paid"`
+	} `json:"project" db:"project"`
 }
 
 type memoAPI struct{}
@@ -208,10 +220,11 @@ func (m *memoAPI) GetMemo(id int, abstractLength int64, memberID int64) (memo Me
 	r := strings.NewReplacer("memos.content", "CASE WHEN (points.object_id IS NULL OR points.object_type IS NULL) THEN SUBSTRING(memos.content, 1, ?) ELSE memos.content END AS content")
 	memoField = r.Replace(memoField)
 
-	err = DB.Get(&result, fmt.Sprintf(`
+	query := fmt.Sprintf(`
 		SELECT %s FROM memos 
 		LEFT JOIN (SELECT DISTINCT object_id, object_type FROM points WHERE object_type = 2 AND member_id = ?) AS points 
-		on memos.project_id = points.object_id WHERE memo_id = ?;`, memoField), abstractLength, memberID, id)
+		on memos.project_id = points.object_id WHERE memo_id = ?;`, memoField)
+	err = DB.Get(&result, query, abstractLength, memberID, id)
 	if err != nil {
 		log.Println(err.Error())
 		switch {
@@ -230,9 +243,41 @@ func (m *memoAPI) GetMemo(id int, abstractLength int64, memberID int64) (memo Me
 }
 func (m *memoAPI) GetMemos(args *MemoGetArgs) (memos []MemoDetail, err error) {
 
-	memoField := strings.Join(makeFieldString("general", `memos.%s`, getStructDBTags("full", Memo{})), ", ")
-	r := strings.NewReplacer("memos.content", "CASE WHEN (points.object_id IS NULL OR points.object_type IS NULL) THEN SUBSTRING(memos.content,1 , ?) ELSE memos.content END AS content")
-	memoField = r.Replace(memoField)
+	// Implementation of business logic
+	// Get paid data for projects and roles data for member
+	var (
+		roleProject string
+		roleArgs    []interface{}
+		isAdmin     bool
+	)
+	roleArgs = append(roleArgs, args.MemberID, args.MemberID)
+	if len(args.Project) > 0 {
+		roleProject = fmt.Sprintf("AND %s IN (?)", "object_id")
+		roleArgs = append(roleArgs, args.Project)
+	}
+
+	// User payment in points would be negative values
+	roleQuery := fmt.Sprintf(`SELECT user.id, user.role, projects.object_type, projects.object_id, points.points FROM
+		(SELECT id, role FROM members WHERE id = ?) AS user
+		LEFT JOIN (SELECT DISTINCT member_id, object_type, object_id FROM points WHERE member_id = ? AND object_type = 2 %s) AS projects ON projects.member_id = user.id
+		LEFT JOIN (SELECT DISTINCT object_id, points FROM points WHERE points < 0) as points ON points.object_id = projects.object_id;`, roleProject)
+
+	roleResult := []struct {
+		ID         int64   `db:"id"`
+		Role       NullInt `db:"role"`
+		ObjectType *int    `db:"object_type"`
+		ObjectID   *int    `db:"object_id"`
+		Points     *int    `db:"points"`
+	}{}
+	roleQuery, roleArgs, err = sqlx.In(roleQuery, roleArgs...)
+	roleQuery = DB.Rebind(roleQuery)
+	if err = DB.Select(&roleResult, roleQuery, roleArgs...); err != nil {
+		return []MemoDetail{}, err
+	}
+
+	if len(roleResult) > 0 && roleResult[0].Role.Valid {
+		isAdmin = (roleResult[0].Role.Int == 9)
+	}
 
 	projectTags := getStructDBTags("full", Project{})
 	projectField := makeFieldString("get", `project.%s "project.%s"`, projectTags)
@@ -254,17 +299,13 @@ func (m *memoAPI) GetMemos(args *MemoGetArgs) (memos []MemoDetail, err error) {
 
 	limit, largs := args.parseLimit()
 	values = append(values, largs...)
-	values = append(values, args.MemberID)
-	// Prepend customized abstract length at the beginning of values
-	values = append([]interface{}{args.AbstractLength}, values...)
 
 	rawQuery := fmt.Sprintf(`
-		SELECT %s, %s, %s FROM 
+		SELECT memos.*, %s, %s FROM 
 		(SELECT memos.* FROM memos LEFT JOIN projects AS project ON project.project_id = memos.project_id %s %s) AS memos 
 		LEFT JOIN members AS author ON author.id = memos.author 
-		LEFT JOIN projects AS project ON project.project_id = memos.project_id 
-		LEFT JOIN (SELECT DISTINCT object_id, object_type FROM points WHERE object_type = 2 AND member_id = ?) AS points on memos.project_id = points.object_id %s;`,
-		memoField, strings.Join(projectField, ","), strings.Join(memberField, ","), restricts, limit["full"], limit["order"])
+		LEFT JOIN projects AS project ON project.project_id = memos.project_id %s;`,
+		strings.Join(projectField, ","), strings.Join(memberField, ","), restricts, limit["full"], limit["order"])
 
 	query, sqlArgs, err := sqlx.In(rawQuery, values...)
 	if err != nil {
@@ -272,7 +313,6 @@ func (m *memoAPI) GetMemos(args *MemoGetArgs) (memos []MemoDetail, err error) {
 		return nil, err
 	}
 	query = DB.Rebind(query)
-
 	rows, err := DB.Queryx(query, sqlArgs...)
 	if err != nil {
 		log.Println("GetMemos query db error", err)
@@ -280,11 +320,33 @@ func (m *memoAPI) GetMemos(args *MemoGetArgs) (memos []MemoDetail, err error) {
 	}
 
 	memos = []MemoDetail{}
+
 	for rows.Next() {
 		var memo MemoDetail
 		if err = rows.StructScan(&memo); err != nil {
 			log.Println("GetMemos scan result error", err)
 			return []MemoDetail{}, err
+		}
+		abstract := []rune(memo.Content.String)
+		abstract = abstract[:int(math.Min(float64(len(memo.Content.String)), float64(args.AbstractLength)))]
+		var fulltext string
+		// Default show abstract
+		if memo.Content.Valid {
+			fulltext = memo.Content.String
+			memo.Content.String = string(abstract)
+		}
+		// Admin show full text whatsoever
+		if isAdmin {
+			memo.Content.String = fulltext
+		} else {
+			for _, project := range roleResult {
+				// Memos belongs to project matches roleResult
+				if project.ObjectID != nil && memo.Project.ID == *project.ObjectID && project.Points != nil {
+					memo.Project.Paid = true
+					memo.Content.String = fulltext
+					break
+				}
+			}
 		}
 		memos = append(memos, memo)
 	}

--- a/routes/memo.go
+++ b/routes/memo.go
@@ -57,7 +57,16 @@ func (r *memoHandler) bindQuery(c *gin.Context, args *models.MemoGetArgs) (err e
 			return err
 		}
 	}
-
+	if c.Query("abstract_length") != "" {
+		if args.AbstractLength, err = strconv.ParseInt(c.Query("abstract_length"), 10, 64); err != nil {
+			return err
+		}
+	}
+	if c.Query("member_id") != "" {
+		if args.MemberID, err = strconv.ParseInt(c.Query("member_id"), 10, 64); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -86,7 +95,12 @@ func (r *memoHandler) GetMany(c *gin.Context) {
 func (r *memoHandler) Get(c *gin.Context) {
 
 	id, _ := strconv.Atoi(c.Param("id"))
-	result, err := models.MemoAPI.GetMemo(id)
+	abstractLength, _ := strconv.ParseInt(c.Query("abstract_length"), 10, 64)
+	if abstractLength == 0 {
+		abstractLength = 20
+	}
+	memberID, _ := strconv.ParseInt(c.Query("member_id"), 10, 64)
+	result, err := models.MemoAPI.GetMemo(id, abstractLength, memberID)
 
 	if err != nil {
 		switch err.Error() {
@@ -159,7 +173,7 @@ func (r *memoHandler) Put(c *gin.Context) {
 		return
 	}
 	if memo.PublishStatus.Valid {
-		result, err := models.MemoAPI.GetMemo(memo.ID)
+		result, err := models.MemoAPI.GetMemo(memo.ID, 20, 0)
 		if err != nil {
 			switch err.Error() {
 			case "Not Found":

--- a/routes/memo.go
+++ b/routes/memo.go
@@ -67,6 +67,10 @@ func (r *memoHandler) bindQuery(c *gin.Context, args *models.MemoGetArgs) (err e
 			return err
 		}
 	}
+	if c.Param("id") != "" {
+		id, _ := strconv.Atoi(c.Param("id"))
+		args.MemoID = int64(id)
+	}
 	return nil
 }
 
@@ -93,15 +97,15 @@ func (r *memoHandler) GetMany(c *gin.Context) {
 }
 
 func (r *memoHandler) Get(c *gin.Context) {
-
-	id, _ := strconv.Atoi(c.Param("id"))
-	abstractLength, _ := strconv.ParseInt(c.Query("abstract_length"), 10, 64)
-	if abstractLength == 0 {
-		abstractLength = 20
+	var args = &models.MemoGetArgs{}
+	if err := r.bindQuery(c, args); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
 	}
-	memberID, _ := strconv.ParseInt(c.Query("member_id"), 10, 64)
-	result, err := models.MemoAPI.GetMemo(id, abstractLength, memberID)
-
+	if args.AbstractLength == 0 {
+		args.AbstractLength = 20
+	}
+	result, err := models.MemoAPI.GetMemos(args)
 	if err != nil {
 		switch err.Error() {
 		case "Not Found":

--- a/routes/memo.go
+++ b/routes/memo.go
@@ -177,7 +177,7 @@ func (r *memoHandler) Put(c *gin.Context) {
 		return
 	}
 	if memo.PublishStatus.Valid {
-		result, err := models.MemoAPI.GetMemo(memo.ID, 20, 0)
+		result, err := models.MemoAPI.GetMemo(memo.ID)
 		if err != nil {
 			switch err.Error() {
 			case "Not Found":

--- a/routes/memo_test.go
+++ b/routes/memo_test.go
@@ -40,6 +40,9 @@ func (m *mockMemoAPI) GetMemo(id int, abstractLength int64, memberID int64) (mem
 }
 func (m *mockMemoAPI) GetMemos(args *models.MemoGetArgs) (memos []models.MemoDetail, err error) {
 	switch {
+	case args.MemoID == 1:
+		return []models.MemoDetail{
+			models.MemoDetail{Memo: models.Memo{ID: 1, Title: models.NullString{"MemoTestDefault1", true}, Author: models.NullInt{131, true}, Project: models.NullInt{420, true}, Active: models.NullInt{1, true}}}}, nil
 	case len(args.Author) > 0 && len(args.Project) > 0:
 		return []models.MemoDetail{
 			models.MemoDetail{Memo: models.Memo{ID: 4, Title: models.NullString{"MemoTestDefault4", true}, Author: models.NullInt{135, true}, Project: models.NullInt{422, true}, Active: models.NullInt{1, true}}},
@@ -218,7 +221,10 @@ func TestRouteMemos(t *testing.T) {
 	})
 	t.Run("GetMemo", func(t *testing.T) {
 		for _, testcase := range []genericTestcase{
-			genericTestcase{"GetMemoOK", "GET", "/memo/1", ``, http.StatusOK, `{"_items":{"id":1,"created_at":null,"comment_amount":null,"title":"MemoTestDefault1","content":null,"link":null,"author":131,"project_id":420,"active":1,"updated_at":null,"updated_by":null,"published_at":null,"publish_status":null,"memo_order":null}}`},
+			// genericTestcase{"GetMemoOK", "GET", "/memo/1", ``, http.StatusOK, `{"_items":{"id":1,"created_at":null,"comment_amount":null,"title":"MemoTestDefault1","content":null,"link":null,"author":131,"project_id":420,"active":1,"updated_at":null,"updated_by":null,"published_at":null,"publish_status":null,"memo_order":null}}`},
+			genericTestcase{"GetMemoOK", "GET", "/memo/1", ``, http.StatusOK, []models.Memo{
+				models.Memo{ID: 1, Title: models.NullString{"MemoTestDefault1", true}, Author: models.NullInt{131, true}, Project: models.NullInt{420, true}, Active: models.NullInt{1, true}},
+			}},
 		} {
 			genericDoTest(testcase, t, asserter)
 		}

--- a/routes/memo_test.go
+++ b/routes/memo_test.go
@@ -29,7 +29,7 @@ func (m *mockMemoAPI) CountMemos(args *models.MemoGetArgs) (count int, err error
 	}
 	return 0, nil
 }
-func (m *mockMemoAPI) GetMemo(id int, abstractLength int64, memberID int64) (memo models.Memo, err error) {
+func (m *mockMemoAPI) GetMemo(id int) (memo models.Memo, err error) {
 
 	for _, v := range mockMemoDS {
 		if v.ID == id {

--- a/routes/memo_test.go
+++ b/routes/memo_test.go
@@ -29,7 +29,7 @@ func (m *mockMemoAPI) CountMemos(args *models.MemoGetArgs) (count int, err error
 	}
 	return 0, nil
 }
-func (m *mockMemoAPI) GetMemo(id int) (memo models.Memo, err error) {
+func (m *mockMemoAPI) GetMemo(id int, abstractLength int64, memberID int64) (memo models.Memo, err error) {
 
 	for _, v := range mockMemoDS {
 		if v.ID == id {


### PR DESCRIPTION
1. Abstract content in both `GET /memos` and `GET /memo`
Default contents for memo response are abstract. Only admin users could see full content for every memos. Normal users could only see full content of memos in projects they had paid for before. Two request parameters were introduced: *member_id* and *abstract_length*

- abstract_length is used to restrain content to specific length if it should be returned in abstract mode. If content are less than `abstract_length`, they are showed in full text. Default is 20.

>>Example:
>>To make content less than 35 character, use
>>```bash
>>GET /memos?abstract_length=35
>>```

- member_id is used to ask API to return content according to the payment situation of specific member. Those memos content in projects the member has paid for will be full text,
otherwise they are in abstract. Ignore this argument made all memos content abstract.

>>Example:
>>To request memos for member with id 648, use
>>```bash
>>GET /memos?member_id=648
>>```

- Other paramters remain as before. e.g. `/memos` has project_id. Use `GET /memos?project_id=[1,3]` to get memos belongs to project 1 and 3. *But* when project_id used together with `/memo/`, There could be no result if project_id does not match the real project id the memo belongs to.

@tempo0829 , Please check this

2. New `paid` parameter in project object of memos
- If member has already paid for this project, `paid` would be true

3. Integrated database api for both `/memo/` and `/memos` endpoints
- Due to same return requirement for both memo and memos, they are now using identical database api. The request usage remain the same, but response for `/memo` would become exactly like `/memos`, which is an array with only one result

@chiangkeith 

Other features using old GetMemo (e.g. generateCommentNotifications) remain the same.

4. Included general mode for makeFieldString
- All the other mode could be replaced with this mode. It could be refactored in the future.

5. Corresponding test change.