### PR TITLE
Receive Comment resource type and id

### DIFF
--- a/routes/comment.go
+++ b/routes/comment.go
@@ -165,11 +165,22 @@ func (r *commentsHandler) PutRC(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+func (r *commentsHandler) UpdateCommentCounts(c *gin.Context) {
+	err := models.CommentAPI.UpdateAllCommentAmount()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+
+	c.Status(http.StatusOK)
+}
+
 func (r *commentsHandler) SetRoutes(router *gin.Engine) {
 	commentsRouter := router.Group("/comment")
 	{
 		commentsRouter.GET("/:id", r.GetComment)
 		commentsRouter.GET("", r.GetComments)
+		commentsRouter.PUT("/counts", r.UpdateCommentCounts)
 	}
 	reportcommentsRouter := router.Group("/reported_comment")
 	{

--- a/routes/mail.go
+++ b/routes/mail.go
@@ -91,9 +91,8 @@ func (r *mailHandler) SendDailyDigest(c *gin.Context) {
 func (r *mailHandler) SetRoutes(router *gin.Engine, dialer gomail.Dialer) {
 	router.POST("/mail", r.sendMail)
 	router.POST("/mail/updatenote", r.updateNote)
-	//router.POST("/mail/dailydigest", r.dailyDigest)
-	router.GET("/mail/gendailydigest", r.GenDailyDigest)
-	router.GET("/mail/senddailydigest", r.SendDailyDigest)
+	router.POST("/mail/gendailydigest", r.GenDailyDigest)
+	router.POST("/mail/senddailydigest", r.SendDailyDigest)
 
 	models.MailAPI.SetDialer(dialer)
 }

--- a/routes/pubsub.go
+++ b/routes/pubsub.go
@@ -198,7 +198,14 @@ func (r *pubsubHandler) Push(c *gin.Context) {
 
 			err = models.CommentAPI.UpdateComment(comment)
 			if err != nil {
-				log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				log.Printf("%s %s UpdateComment fail: %v \n", msgType, actionType, err.Error())
+			}
+
+			if comment.Status.Valid || comment.Active.Valid {
+				err = models.CommentAPI.UpdateAllCommentAmount()
+				if err != nil {
+					log.Printf("%s %s UpdateAllCommentAmount fail: %v \n", msgType, actionType, err.Error())
+				}
 			}
 
 			c.Status(http.StatusOK)
@@ -235,6 +242,13 @@ func (r *pubsubHandler) Push(c *gin.Context) {
 					log.Printf("%s %s fail: %v \n", msgType, actionType, "Comments Not Found")
 				default:
 					log.Printf("%s %s fail: %v \n", msgType, actionType, err.Error())
+				}
+			}
+
+			if args.Status.Valid || args.Active.Valid {
+				err = models.CommentAPI.UpdateAllCommentAmount()
+				if err != nil {
+					log.Printf("%s %s UpdateAllCommentAmount fail: %v \n", msgType, actionType, err.Error())
 				}
 			}
 


### PR DESCRIPTION
1. Receive resource name and id as the parameter when post a new comment, send notifications and update comment count according to the info sent.
2. As to updating and deleting comments, there's no additional to ensure which resource the comment belongs to, so update all comments of all resources.
3. Fix comment count accumulation.