### PR TITLE
Refactor following API

### DIFF
--- a/db_schema/12_integrate_follow_down.sql
+++ b/db_schema/12_integrate_follow_down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE report_authors DROP INDEX unique_author;
+
+DROP TABLE IF EXISTS `following`;

--- a/db_schema/12_integrate_follow_up.sql
+++ b/db_schema/12_integrate_follow_up.sql
@@ -1,0 +1,15 @@
+ALTER TABLE report_authors ADD UNIQUE unique_author(author_id, report_id);
+
+CREATE TABLE `following` (
+    `id` BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    `type` TINYINT(1) NOT NULL DEFAULT 0,
+    `member_id` BIGINT UNSIGNED NOT NULL,
+    `target_id` BIGINT UNSIGNED NOT NULL,
+    `emotion` TINYINT(1) NOT NULL DEFAULT 0,
+    `created_at` DATETIME DEFAULT NOW(),
+    CONSTRAINT type_member_target UNIQUE (type, member_id, target_id, emotion)
+)ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO `following` (type, member_id, target_id, created_at) SELECT 1, following_members.member_id, following_members.custom_editor, following_members.created_at FROM following_members;
+INSERT IGNORE INTO `following` (type, member_id, target_id, created_at) SELECT 2, following_posts.member_id, following_posts.post_id, following_posts.created_at FROM following_posts;
+INSERT IGNORE INTO `following` (type, member_id, target_id, created_at) SELECT 3, following_projects.member_id, following_projects.project_id, following_projects.created_at FROM following_projects;

--- a/models/comments.go
+++ b/models/comments.go
@@ -591,14 +591,23 @@ func (c *commentAPI) generateCommentNotifications(comment InsertCommentArgs) (er
 			log.Println("Error get post", resourceID, err.Error())
 		}
 
-		postFollowers, err := FollowingAPI.GetFollowerMemberIDs("post", resourceIDStr)
+		postInterface, err := FollowingAPI.Get(&GetFollowerMemberIDsArgs{int64(resourceID), 2})
 		if err != nil {
 			log.Println("Error get post followers", resourceIDStr, err.Error())
 		}
+		postFollowers, ok := postInterface.([]int)
+		if !ok {
+			log.Println("Error assert projectInterface ", err.Error())
+		}
+		log.Println(postFollowers)
 
-		authorFollowers, err := FollowingAPI.GetFollowerMemberIDs("member", strconv.Itoa(int(post.Author.Int)))
+		authorInterface, err := FollowingAPI.Get(&GetFollowerMemberIDsArgs{int64(post.Author.Int), 1})
 		if err != nil {
 			log.Println("Error get author followers", commentDetail.Author.Int, err.Error())
+		}
+		authorFollowers, ok := authorInterface.([]int)
+		if !ok {
+			log.Println("Error assert projectInterface ", err.Error())
 		}
 		log.Println(authorFollowers)
 
@@ -669,9 +678,13 @@ func (c *commentAPI) generateCommentNotifications(comment InsertCommentArgs) (er
 			log.Println("Error get project", resourceID, err.Error())
 		}
 
-		projectFollowers, err := FollowingAPI.GetFollowerMemberIDs("project", resourceIDStr)
+		projectInterface, err := FollowingAPI.Get(&GetFollowerMemberIDsArgs{int64(resourceID), 3})
 		if err != nil {
 			log.Println("Error get project followers", resourceIDStr, err.Error())
+		}
+		projectFollowers, ok := projectInterface.([]int)
+		if !ok {
+			log.Println("Error assert projectInterface ", err.Error())
 		}
 
 		var commentors []int
@@ -726,12 +739,15 @@ func (c *commentAPI) generateCommentNotifications(comment InsertCommentArgs) (er
 		if err != nil {
 			log.Println("Error get memo", resourceID, err.Error())
 		}
-
-		projectFollowers, err := FollowingAPI.GetFollowerMemberIDs("project", strconv.Itoa(int(memo.Project.Int)))
+		// params :=
+		projectInterface, err := FollowingAPI.Get(&GetFollowerMemberIDsArgs{ID: int64(memo.Project.Int), FollowType: 3})
 		if err != nil {
 			log.Println("Error get project followers", memo.Project.Int, err.Error())
 		}
-
+		projectFollowers, ok := projectInterface.([]int)
+		if !ok {
+			log.Println("Error assert projectInterface at memo", err.Error())
+		}
 		var commentors []int
 		rows, err := DB.Queryx(fmt.Sprintf(`SELECT DISTINCT author FROM comments WHERE resource="%s" AND status = %d AND active = %d;`, commentDetail.Resource.String, int(CommentStatus["show"].(float64)), int(CommentActive["active"].(float64))))
 		if err != nil {

--- a/models/follows.go
+++ b/models/follows.go
@@ -8,260 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"database/sql"
-
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 )
 
-/* ================================================ Types of Followings ================================================ */
-
-type follow interface {
-	Delete() (sql.Result, error)
-	GetFollowed(args GetFollowedArgs) (*sqlx.Rows, error)
-	GetFollowings(args GetFollowingArgs) (*sqlx.Rows, error)
-	GetFollowerMemberIDs(id string) ([]int, error)
-	GetMap(args GetFollowMapArgs) (*sqlx.Rows, error)
-	Insert() (sql.Result, error)
-}
-
-type followPost struct {
-	ID     int64
-	Object int64
-}
-
-func (f followPost) Insert() (sql.Result, error) {
-	query := "INSERT INTO following_posts (member_id, post_id) VALUES ( ? , ? );"
-	return DB.Exec(query, f.ID, f.Object)
-}
-func (f followPost) Delete() (sql.Result, error) {
-	query := "DELETE FROM following_posts WHERE member_id = ? AND post_id = ?;"
-	return DB.Exec(query, f.ID, f.Object)
-}
-func (f followPost) GetFollowings(params GetFollowingArgs) (*sqlx.Rows, error) {
-	post_type := f.postTypeHelper(params.Type)
-	return DB.Queryx(fmt.Sprintf("SELECT p.* from posts as p INNER JOIN following_posts as f ON p.post_id = f.post_id WHERE p.active = 1 AND f.member_id = ? %s ORDER BY f.created_at DESC;", post_type), f.ID)
-}
-func (f followPost) GetFollowed(params GetFollowedArgs) (*sqlx.Rows, error) {
-	post_type := f.postTypeHelper(params.Type)
-	query, args, err := sqlx.In(fmt.Sprintf("SELECT f.post_id, COUNT(m.id) as count, GROUP_CONCAT(m.id SEPARATOR ',') as follower FROM posts AS p LEFT JOIN following_posts as f ON f.post_id = p.post_id LEFT JOIN members as m ON f.member_id = m.id WHERE f.post_id IN (?) %s GROUP BY f.post_id;", post_type), params.Ids)
-	if err != nil {
-		return nil, err
-	}
-	return DB.Queryx(query, args...)
-}
-func (f followPost) GetFollowerMemberIDs(id string) (result []int, err error) {
-	rows, err := DB.Query(fmt.Sprintf(`SELECT member_id AS member_id FROM following_posts WHERE post_id=%s;`, id))
-	if err != nil {
-		log.Println("Error get postFollowers", id, err.Error())
-	}
-	for rows.Next() {
-		var follower int
-		err = rows.Scan(&follower)
-		if err != nil {
-			log.Println("Error scan postFollowers", id, err.Error())
-		}
-		result = append(result, follower)
-	}
-	return result, err
-}
-func (f followPost) GetMap(params GetFollowMapArgs) (*sqlx.Rows, error) {
-	post_type := f.postTypeHelper(params.Type)
-	query := fmt.Sprintf(`
-		SELECT GROUP_CONCAT(member_resource.member_id) AS member_ids, member_resource.resource_ids
-		FROM (
-			SELECT GROUP_CONCAT(fp.post_id) AS resource_ids, m.id AS member_id
-			FROM following_posts AS fp
-			LEFT JOIN members AS m ON fp.member_id = m.id
-			LEFT JOIN posts AS p ON p.post_id = fp.post_id
-			WHERE m.active = ?
-				AND m.post_push = ?
-				AND p.active = ?
-				AND p.publish_status = ?
-				AND p.updated_at > ?
-				%s
-			GROUP BY m.id
-			) AS member_resource
-		GROUP BY member_resource.resource_ids;`, post_type)
-	return DB.Queryx(query, int(MemberStatus["active"].(float64)), 1, int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), params.UpdateAfter)
-}
-func (f followPost) postTypeHelper(post_type string) string {
-	if t := PostType[post_type]; t == nil {
-		return ""
-	} else {
-		return fmt.Sprintf(" AND p.type = %d", int(t.(float64)))
-	}
-}
-
-type followMember struct {
-	ID     int64
-	Object int64
-}
-
-func (f followMember) Insert() (sql.Result, error) {
-	query := "INSERT INTO following_members (member_id, custom_editor) VALUES ( ? , ? );"
-	return DB.Exec(query, f.ID, f.Object)
-}
-
-func (f followMember) Delete() (sql.Result, error) {
-	query := "DELETE FROM following_members WHERE member_id = ? AND custom_editor = ?;"
-	return DB.Exec(query, f.ID, f.Object)
-}
-func (f followMember) GetFollowings(params GetFollowingArgs) (*sqlx.Rows, error) {
-	return DB.Queryx("SELECT m.* from members as m INNER JOIN following_members as f ON m.id = f.custom_editor WHERE m.active > 0 AND f.member_id = ? ORDER BY f.created_at DESC;", f.ID)
-}
-func (f followMember) GetFollowed(params GetFollowedArgs) (*sqlx.Rows, error) {
-	query, args, err := sqlx.In("SELECT f.custom_editor, COUNT(m.id) as count, GROUP_CONCAT(m.id SEPARATOR ',') as follower FROM following_members as f LEFT JOIN members as m ON f.member_id = m.id WHERE f.custom_editor IN (?) GROUP BY f.custom_editor;", params.Ids)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Printf("followMember GetFollwed sql:%s,\nargs:%v\n", query, args)
-	return DB.Queryx(query, args...)
-}
-func (f followMember) GetFollowerMemberIDs(id string) (result []int, err error) {
-	rows, err := DB.Query(fmt.Sprintf(`SELECT member_id FROM following_members WHERE custom_editor="%s";`, id))
-	if err != nil {
-		log.Println("Error get authorFollowers", id, err.Error())
-	}
-	for rows.Next() {
-		var follower int
-		err = rows.Scan(&follower)
-		if err != nil {
-			log.Println("Error scan authorFollowers", id, err.Error())
-		}
-		result = append(result, follower)
-	}
-	return result, err
-}
-func (f followMember) GetMap(params GetFollowMapArgs) (*sqlx.Rows, error) {
-	query := `
-		SELECT GROUP_CONCAT(member_resource.member_id) AS member_ids, member_resource.resource_ids
-		FROM (
-			SELECT GROUP_CONCAT(p.post_id) AS resource_ids, m.id AS member_id
-			FROM following_members AS f
-			LEFT JOIN members AS m ON f.member_id = m.id
-			LEFT JOIN members AS e ON f.custom_editor = e.id
-			LEFT JOIN posts AS p ON f.custom_editor = p.author
-			WHERE m.active = ?
-				AND m.post_push = ?
-				AND e.active = ?
-				AND p.active = ?
-				AND p.publish_status = ?
-				AND p.updated_at > ?
-			GROUP BY m.id ) AS member_resource
-		GROUP BY member_resource.resource_ids;`
-	return DB.Queryx(query, int(MemberStatus["active"].(float64)), 1, int(MemberStatus["active"].(float64)), int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), params.UpdateAfter)
-}
-
-type followProject struct {
-	ID     int64
-	Object int64
-}
-
-func (f followProject) Insert() (sql.Result, error) {
-	query := "INSERT INTO following_projects (member_id, project_id) VALUES ( ? , ? );"
-	return DB.Exec(query, f.ID, f.Object)
-}
-func (f followProject) Delete() (sql.Result, error) {
-	query := "DELETE FROM following_projects WHERE member_id = ? AND project_id = ?;"
-	return DB.Exec(query, f.ID, f.Object)
-}
-func (f followProject) GetFollowings(params GetFollowingArgs) (*sqlx.Rows, error) {
-	return DB.Queryx("SELECT m.* from projects as m INNER JOIN following_projects as f ON m.project_id = f.project_id WHERE m.active = 1  AND f.member_id = ? ORDER BY f.created_at DESC;", f.ID)
-}
-func (f followProject) GetFollowed(params GetFollowedArgs) (*sqlx.Rows, error) {
-	query, args, err := sqlx.In("SELECT f.project_id, COUNT(m.id) as count, GROUP_CONCAT(m.id SEPARATOR ',') as follower FROM following_projects as f LEFT JOIN members as m ON f.member_id = m.id WHERE f.project_id IN (?) GROUP BY f.project_id;", params.Ids)
-	if err != nil {
-		return nil, err
-	}
-	return DB.Queryx(query, args...)
-}
-func (f followProject) GetFollowerMemberIDs(id string) (result []int, err error) {
-	rows, err := DB.Query(fmt.Sprintf(`SELECT member_id FROM following_projects WHERE project_id=%s;`, id))
-	if err != nil {
-		log.Println("Error get projectFollowers", id, err.Error())
-	}
-	for rows.Next() {
-		var follower int
-		err = rows.Scan(&follower)
-		if err != nil {
-			log.Println("Error scan authorFollowers", id, err.Error())
-		}
-		result = append(result, follower)
-	}
-	return result, err
-}
-func (f followProject) GetMap(params GetFollowMapArgs) (*sqlx.Rows, error) {
-	query := `
-		SELECT GROUP_CONCAT(member_resource.member_id) AS member_ids, member_resource.resource_ids
-		FROM (
-			SELECT GROUP_CONCAT(f.project_id) AS resource_ids, m.id AS member_id 
-			FROM following_projects AS f
-			LEFT JOIN members AS m ON f.member_id = m.id
-			LEFT JOIN projects AS p ON f.project_id = p.project_id
-			WHERE m.active = ?
-				AND m.post_push = ?
-				AND p.active = ?
-				AND p.publish_status = ?
-				AND p.updated_at > ?
-			GROUP BY m.id
-			) AS member_resource
-		GROUP BY member_resource.resource_ids;`
-	return DB.Queryx(query, int(MemberStatus["active"].(float64)), 1, int(ProjectActive["active"].(float64)), int(ProjectPublishStatus["publish"].(float64)), params.UpdateAfter)
-}
-
-/* ================================================ Follower Factory ================================================ */
-
-func followPostFactory(args FollowArgs) follow {
-	return followPost{
-		ID:     args.Subject,
-		Object: args.Object,
-	}
-}
-func followMemberFactory(args FollowArgs) follow {
-	return followMember{
-		ID:     args.Subject,
-		Object: args.Object,
-	}
-}
-func followProjectFactory(args FollowArgs) follow {
-	return followProject{
-		ID:     args.Subject,
-		Object: args.Object,
-	}
-}
-
-var followFactories = map[string]func(conf FollowArgs) follow{
-	"post":    followPostFactory,
-	"member":  followMemberFactory,
-	"project": followProjectFactory,
-}
-
-func CreateFollow(args FollowArgs) (follow, error) {
-	followFactory, ok := followFactories[args.Resource]
-	if !ok {
-		return nil, errors.New("Resource Not Supported")
-	}
-	return followFactory(args), nil
-}
-
 /* ================================================ Follower API ================================================ */
-
-type FollowingAPIInterface interface {
-	AddFollowing(params FollowArgs) error
-	DeleteFollowing(params FollowArgs) error
-	GetFollowing(params GetFollowingArgs) ([]interface{}, error)
-	GetFollowed(args GetFollowedArgs) (interface{}, error)
-	GetFollowerMemberIDs(resourceType string, id string) ([]int, error)
-	GetFollowMap(args GetFollowMapArgs) ([]FollowingMapItem, error)
-
-	PseudoAddFollowing(params FollowArgs) error
-	PseudoDeleteFollowing(params FollowArgs) error
-	PseudoGetFollowed(params GetFollowArgs) (interface{}, error)
-	PseudoGetFollowing(params GetFollowArgs) (following []interface{}, err error)
-	PseudoGetFollowerMemberIDs(id int64, followType int) (result []int, err error)
-	PseudoGetFollowMap(args GetFollowArgs) (list []FollowingMapItem, err error)
-}
 
 type FollowArgs struct {
 	Resource string
@@ -271,62 +22,18 @@ type FollowArgs struct {
 	Emotion  int
 }
 
+type GetFollowInterface interface {
+	get() (*sqlx.Rows, error)
+	scan(*sqlx.Rows) (interface{}, error)
+}
+
 type GetFollowingArgs struct {
-	MemberId int64  `json:"subject"`
-	Resource string `json:"resource"`
-	Type     string `json:"resource_type,omitempty"`
-}
-
-type GetFollowedArgs struct {
-	Ids      []string `json:"ids"`
-	Resource string   `json:"resource"`
-	Type     string   `json:"resource_type,omitempty"`
-}
-
-type GetFollowMapArgs struct {
-	Resource    string    `json:"resource"`
-	Type        string    `json:"resource_type,omitempty"`
-	UpdateAfter time.Time `json:"updated_after"`
-}
-
-type followedCount struct {
-	Resourceid int64
-	Count      int
-	Follower   []int64
-}
-
-type FollowerInfo struct {
-	MemberId string `json:"member_ids" db:"member_ids"`
-	Name     string `json:"resource_ids" db:"resource_ids"`
-	Mail     string
-}
-
-type FollowingMapItem struct {
-	Followers   []string `json:"member_ids" db:"member_ids"`
-	ResourceIDs []string `json:"resource_ids" db:"resource_ids"`
-}
-
-type followingAPI struct{}
-
-// ============================= Refactor ======================
-type GetFollowArgs struct {
-	IDs         []int64   `json:"ids"`
-	UpdateAfter time.Time `form:"updated_after" json:"updated_after"`
-	Type        int
-	Method      string
-	Active      map[string][]int
+	MemberID int64 `form:"id" json:"id"`
+	Active   map[string][]int
 	Resource
 }
 
-type Resource struct {
-	ResourceName string `form:"resource" json:"resource"`
-	ResourceType string `form:"resource_type" json:"resource_type, omitempty"` //review, report ...
-	TableName    string
-	KeyName      string
-}
-
-func (g GetFollowArgs) following() (result string, values []interface{}) {
-
+func (g *GetFollowingArgs) get() (*sqlx.Rows, error) {
 	var osql = struct {
 		base      string
 		condition []string
@@ -336,9 +43,9 @@ func (g GetFollowArgs) following() (result string, values []interface{}) {
 		base: `SELECT t.* FROM %s AS t 
 		INNER JOIN following AS f ON t.%s = f.target_id
 		WHERE %s ORDER BY f.created_at DESC;`,
-		printargs: []interface{}{g.TableName, g.KeyName},
+		printargs: []interface{}{g.Table, g.PrimaryKey},
 		condition: []string{"f.type = ?", "f.member_id = ?"},
-		args:      []interface{}{g.Type, g.IDs[0]},
+		args:      []interface{}{g.FollowType, g.MemberID},
 	}
 	if g.Active != nil {
 		for k, v := range g.Active {
@@ -348,132 +55,26 @@ func (g GetFollowArgs) following() (result string, values []interface{}) {
 	}
 	osql.printargs = append(osql.printargs, strings.Join(osql.condition, " AND "))
 
-	return fmt.Sprintf(osql.base, osql.printargs...), osql.args
-}
-
-func (g GetFollowArgs) followed() (result string, values []interface{}) {
-
-	var osql = struct {
-		base      string
-		condition []string
-		join      []string
-		args      []interface{}
-	}{
-		base: `SELECT f.target_id, COUNT(m.id) as count, 
-		GROUP_CONCAT(m.id SEPARATOR ',') as follower FROM following as f 
-		LEFT JOIN %s WHERE %s GROUP BY f.target_id;`,
-		condition: []string{"f.target_id IN (?)", "f.type = ?"},
-		join:      []string{"members AS m ON f.member_id = m.id"},
-		args:      []interface{}{g.IDs, g.Type},
-	}
-	if g.ResourceName == "post" {
-		osql.join = append(osql.join, "posts AS p ON f.target_id = p.post_id")
-
-		if t := PostType[g.ResourceType]; t != nil {
-			osql.condition = append(osql.condition, "p.type = ?")
-			osql.args = append(osql.args, int(t.(float64)))
-		}
-	}
-	result = fmt.Sprintf(osql.base, strings.Join(osql.join, " LEFT JOIN "), strings.Join(osql.condition, " AND "))
-	return result, osql.args
-}
-
-func (g GetFollowArgs) getmap() (result string, values []interface{}) {
-
-	var osql = struct {
-		base      string
-		condition []string
-		join      []string
-		args      []interface{}
-	}{
-		base: `SELECT GROUP_CONCAT(member_resource.member_id) AS member_ids, member_resource.resource_ids
-			FROM (
-				SELECT GROUP_CONCAT(f.target_id) AS resource_ids, m.id AS member_id 
-				FROM following AS f
-				LEFT JOIN %s
-				WHERE %s
-				GROUP BY m.id
-				) AS member_resource
-			GROUP BY member_resource.resource_ids;`,
-		join:      []string{"members AS m ON f.member_id = m.id", fmt.Sprintf("%s AS t ON f.target_id = t.%s", g.TableName, g.KeyName)},
-		condition: []string{"m.active = ?", "m.post_push = ?"},
-		args:      []interface{}{int(MemberStatus["active"].(float64)), 1},
-	}
-
-	switch g.ResourceName {
-	case "member":
-		osql.join = append(osql.join, "posts AS p ON f.target_id = p.author")
-		osql.condition = append(osql.condition, "t.active = ?", "p.active = ?", "p.publish_status = ?", "p.updated_at > ?")
-		osql.args = append(osql.args, int(MemberStatus["active"].(float64)), int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), g.UpdateAfter)
-	case "post":
-		osql.condition = append(osql.condition, "t.active = ?", "t.publish_status = ?", "t.updated_at > ?")
-		osql.args = append(osql.args, int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), g.UpdateAfter)
-	case "project":
-		osql.condition = append(osql.condition, "t.active = ?", "t.publish_status = ?", "t.updated_at > ?")
-		osql.args = append(osql.args, int(ProjectActive["active"].(float64)), int(ProjectPublishStatus["publish"].(float64)), g.UpdateAfter)
-	}
-	result = fmt.Sprintf(osql.base, strings.Join(osql.join, " LEFT JOIN "), strings.Join(osql.condition, " AND "))
-	return result, osql.args
-}
-
-func (f *followingAPI) PseudoAddFollowing(params FollowArgs) (err error) {
-	query := `INSERT INTO following_posts (member_id, target_id, type, emotion) VALUES ( ? , ?, ?, ?);`
-
-	result, err := DB.Exec(query, params.Subject, params.Object, params.Type, params.Emotion)
-	if err != nil {
-		sqlerr, ok := err.(*mysql.MySQLError)
-		if ok && sqlerr.Number == 1062 {
-			return DuplicateError
-		}
-		log.Println(err.Error())
-		return InternalServerError
-	}
-	changed, err := result.RowsAffected()
-	if err != nil {
-		log.Println(err.Error())
-		return InternalServerError
-	}
-	if changed == 0 {
-		return SQLInsertionFail
-	}
-
-	if params.Resource == "post" {
-		go PostCache.UpdateFollowing("follow", params.Subject, params.Object)
-	}
-	return nil
-}
-
-func (f *followingAPI) PseudoDeleteFollowing(params FollowArgs) (err error) {
-
-	query := `DELETE FROM following_posts WHERE member_id = ? AND target_id = ? AND type = ? AND emotion = ?;`
-	_, err = DB.Exec(query, params.Subject, params.Object, params.Type, params.Emotion)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if params.Resource == "post" {
-		go PostCache.UpdateFollowing("unfollow", params.Subject, params.Object)
-	}
-
-	return err
-}
-
-// Following is the subject a user following
-func (f *followingAPI) PseudoGetFollowing(params GetFollowArgs) (followings []interface{}, err error) {
-
-	query, args := params.following()
-
-	query, args, err = sqlx.In(query, args...)
+	query, args, err := sqlx.In(fmt.Sprintf(osql.base, osql.printargs...), osql.args...)
 	query = DB.Rebind(query)
 
 	rows, err := DB.Queryx(query, args...)
 	if err != nil {
 		return nil, err
 	}
+	return rows, err
+}
+
+func (g *GetFollowingArgs) scan(rows *sqlx.Rows) (interface{}, error) {
+
+	var (
+		followings []interface{}
+		err        error
+	)
 
 	for rows.Next() {
 
-		switch params.ResourceName {
+		switch g.ResourceName {
 		case "post":
 			var post Post
 			err = rows.StructScan(&post)
@@ -494,6 +95,8 @@ func (f *followingAPI) PseudoGetFollowing(params GetFollowArgs) (followings []in
 			var report Report
 			err = rows.StructScan(&report)
 			followings = append(followings, report)
+		default:
+			return nil, errors.New("Unsupported Resource")
 		}
 
 		if err != nil {
@@ -505,23 +108,52 @@ func (f *followingAPI) PseudoGetFollowing(params GetFollowArgs) (followings []in
 	if len(followings) == 0 {
 		err = errors.New("Not Found")
 	}
-
-	return followings, err
+	return followings, nil
 }
 
-func (f *followingAPI) PseudoGetFollowed(params GetFollowArgs) (result interface{}, err error) {
+type GetFollowedArgs struct {
+	IDs []int64 `json:"ids"`
+	Resource
+}
 
-	query, args := params.followed()
+func (g *GetFollowedArgs) get() (*sqlx.Rows, error) {
+	var osql = struct {
+		base      string
+		condition []string
+		join      []string
+		args      []interface{}
+	}{
+		base: `SELECT f.target_id, COUNT(m.id) as count, 
+		GROUP_CONCAT(m.id SEPARATOR ',') as follower FROM following as f 
+		LEFT JOIN %s WHERE %s GROUP BY f.target_id;`,
+		condition: []string{"f.target_id IN (?)", "f.type = ?"},
+		join:      []string{"members AS m ON f.member_id = m.id"},
+		args:      []interface{}{g.IDs, g.FollowType},
+	}
+	if g.ResourceName == "post" {
+		osql.join = append(osql.join, "posts AS p ON f.target_id = p.post_id")
 
-	query, args, err = sqlx.In(query, args...)
-	query = DB.Rebind(query)
+		if t := PostType[g.ResourceType]; t != nil {
+			osql.condition = append(osql.condition, "p.type = ?")
+			osql.args = append(osql.args, int(t.(float64)))
+		}
+	}
 
-	rows, err := DB.Queryx(query, args...)
+	query, args, err := sqlx.In(fmt.Sprintf(osql.base, strings.Join(osql.join, " LEFT JOIN "), strings.Join(osql.condition, " AND ")), osql.args...)
 	if err != nil {
 		return nil, err
 	}
+	query = DB.Rebind(query)
 
-	followed := []interface{}{}
+	return DB.Queryx(query, args...)
+}
+
+func (g *GetFollowedArgs) scan(rows *sqlx.Rows) (interface{}, error) {
+
+	var (
+		followed []interface{}
+		err      error
+	)
 	for rows.Next() {
 		var (
 			resourceID int64
@@ -550,73 +182,59 @@ func (f *followingAPI) PseudoGetFollowed(params GetFollowArgs) (result interface
 	return followed, nil
 }
 
-func (f *followingAPI) GetFollowing(params GetFollowingArgs) (followings []interface{}, err error) {
-	follow, err := CreateFollow(FollowArgs{Resource: params.Resource, Subject: params.MemberId})
+type GetFollowMapArgs struct {
+	UpdateAfter time.Time `form:"updated_after" json:"updated_after"`
+	Resource
+}
+
+func (g *GetFollowMapArgs) get() (*sqlx.Rows, error) {
+	var osql = struct {
+		base      string
+		condition []string
+		join      []string
+		args      []interface{}
+	}{
+		base: `SELECT GROUP_CONCAT(member_resource.member_id) AS member_ids, member_resource.resource_ids
+			FROM (
+				SELECT GROUP_CONCAT(f.target_id) AS resource_ids, m.id AS member_id 
+				FROM following AS f
+				LEFT JOIN %s
+				WHERE %s
+				GROUP BY m.id
+				) AS member_resource
+			GROUP BY member_resource.resource_ids;`,
+		join:      []string{"members AS m ON f.member_id = m.id", fmt.Sprintf("%s AS t ON f.target_id = t.%s", g.Table, g.PrimaryKey)},
+		condition: []string{"m.active = ?", "m.post_push = ?", "f.type = ?"},
+		args:      []interface{}{int(MemberStatus["active"].(float64)), 1, g.FollowType},
+	}
+
+	switch g.ResourceName {
+	case "member":
+		osql.join = append(osql.join, "posts AS p ON f.target_id = p.author")
+		osql.condition = append(osql.condition, "t.active = ?", "p.active = ?", "p.publish_status = ?", "p.updated_at > ?")
+		osql.args = append(osql.args, int(MemberStatus["active"].(float64)), int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), g.UpdateAfter)
+	case "post":
+		osql.condition = append(osql.condition, "t.active = ?", "t.publish_status = ?", "t.updated_at > ?")
+		osql.args = append(osql.args, int(PostStatus["active"].(float64)), int(PostPublishStatus["publish"].(float64)), g.UpdateAfter)
+	case "project":
+		osql.condition = append(osql.condition, "t.active = ?", "t.publish_status = ?", "t.updated_at > ?")
+		osql.args = append(osql.args, int(ProjectActive["active"].(float64)), int(ProjectPublishStatus["publish"].(float64)), g.UpdateAfter)
+	}
+
+	rows, err := DB.Queryx(fmt.Sprintf(osql.base, strings.Join(osql.join, " LEFT JOIN "), strings.Join(osql.condition, " AND ")), osql.args...)
 	if err != nil {
 		log.Println(err.Error())
 		return nil, err
 	}
-
-	rows, err := follow.GetFollowings(params)
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
-
-	for rows.Next() {
-		if params.Resource == "post" {
-			var post Post
-			err = rows.StructScan(&post)
-			followings = append(followings, post)
-		} else if params.Resource == "project" {
-			var project Project
-			err = rows.StructScan(&project)
-			followings = append(followings, project)
-		} else if params.Resource == "member" {
-			var member Member
-			err = rows.StructScan(&member)
-			followings = append(followings, member)
-		}
-
-		if err != nil {
-			log.Println(err.Error())
-			return followings, err
-		}
-	}
-
-	if len(followings) == 0 {
-		err = errors.New("Not Found")
-	}
-
-	return followings, err
-}
-func (f *followingAPI) PseudoGetFollowerMemberIDs(id int64, followType int) (result []int, err error) {
-
-	rows, err := DB.Query(`SELECT member_id FROM following WHERE target_id = ? AND type = ?;`, id, followType)
-	if err != nil {
-		log.Printf("Error: %v get Follower for id:%d, type:%d\n", err.Error(), id, followType)
-	}
-	for rows.Next() {
-		var follower int
-		err = rows.Scan(&follower)
-		if err != nil {
-			log.Printf("Error: %v scan for id:%d, type:%d\n", err.Error(), id, followType)
-		}
-		result = append(result, follower)
-	}
-	return result, err
+	return rows, err
 }
 
-func (f *followingAPI) PseudoGetFollowMap(params GetFollowArgs) (list []FollowingMapItem, err error) {
+func (g *GetFollowMapArgs) scan(rows *sqlx.Rows) (interface{}, error) {
 
-	query, args := params.getmap()
-
-	rows, err := DB.Queryx(query, args...)
-	if err != nil {
-		log.Println(err.Error())
-		return []FollowingMapItem{}, err
-	}
-
+	var (
+		list []FollowingMapItem
+		err  error
+	)
 	for rows.Next() {
 		var memberIDs, resourceIDs string
 		if err = rows.Scan(&memberIDs, &resourceIDs); err != nil {
@@ -631,93 +249,101 @@ func (f *followingAPI) PseudoGetFollowMap(params GetFollowArgs) (list []Followin
 	return list, nil
 }
 
-func (f *followingAPI) GetFollowed(args GetFollowedArgs) (interface{}, error) {
-	follow, err := CreateFollow(FollowArgs{Resource: args.Resource})
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
+type GetFollowerMemberIDsArgs struct {
+	ID         int64
+	FollowType int
+}
 
-	rows, err := follow.GetFollowed(args)
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
+func (g *GetFollowerMemberIDsArgs) get() (*sqlx.Rows, error) {
 
-	followed := []followedCount{}
+	rows, err := DB.Queryx(`SELECT member_id FROM following WHERE target_id = ? AND type = ?;`, g.ID, g.FollowType)
+	if err != nil {
+		log.Printf("Error: %v get Follower for id:%d, type:%d\n", err.Error(), g.ID, g.FollowType)
+	}
+	return rows, err
+
+}
+
+func (g *GetFollowerMemberIDsArgs) scan(rows *sqlx.Rows) (interface{}, error) {
+	var (
+		result []int
+		err    error
+	)
 	for rows.Next() {
-		var (
-			resourceId int64
-			count      int
-			follower   string
-		)
-		err = rows.Scan(&resourceId, &count, &follower)
+		var follower int
+		err = rows.Scan(&follower)
 		if err != nil {
-			log.Fatalln(err.Error())
-			return nil, err
+			log.Printf("Error: %v scan for id:%d, type:%d\n", err.Error(), g.ID, g.FollowType)
 		}
-		var followers []int64
-		for _, v := range strings.Split(follower, ",") {
-			i, err := strconv.Atoi(v)
-			if err != nil {
-				return nil, err
-			}
-			followers = append(followers, int64(i))
-		}
-		followed = append(followed, followedCount{resourceId, count, followers})
+		result = append(result, follower)
 	}
-	return followed, nil
-}
-func (f *followingAPI) GetFollowerMemberIDs(resourceType string, id string) ([]int, error) {
-	follow, err := CreateFollow(FollowArgs{Resource: resourceType})
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
-
-	ids, err := follow.GetFollowerMemberIDs(id)
-	if err != nil {
-		log.Println(err.Error())
-		return nil, err
-	}
-
-	return ids, nil
-}
-func (f *followingAPI) GetFollowMap(args GetFollowMapArgs) (list []FollowingMapItem, err error) {
-	follow, err := CreateFollow(FollowArgs{Resource: args.Resource})
-	if err != nil {
-		log.Println(err.Error())
-		return []FollowingMapItem{}, err
-	}
-
-	rows, err := follow.GetMap(args)
-	if err != nil {
-		log.Println(err.Error())
-		return []FollowingMapItem{}, err
-	}
-
-	for rows.Next() {
-		var member_ids, resource_ids string
-		if err = rows.Scan(&member_ids, &resource_ids); err != nil {
-			log.Println(err)
-			return []FollowingMapItem{}, err
-		}
-		list = append(list, FollowingMapItem{
-			strings.Split(member_ids, ","),
-			strings.Split(resource_ids, ","),
-		})
-	}
-	return list, nil
+	return result, err
 }
 
-func (f *followingAPI) AddFollowing(params FollowArgs) error {
-	follow, err := CreateFollow(params)
-	if err != nil {
-		log.Println(err.Error())
-		return err
-	}
+type Resource struct {
+	ResourceName string `form:"resource" json:"resource"`
+	ResourceType string `form:"resource_type" json:"resource_type, omitempty"`
+	FollowType   int
+	Table        string
+	PrimaryKey   string
+}
 
-	result, err := follow.Insert()
+type followedCount struct {
+	Resourceid int64
+	Count      int
+	Follower   []int64
+}
+
+// type FollowerInfo struct {
+// 	MemberId string `json:"member_ids" db:"member_ids"`
+// 	Name     string `json:"resource_ids" db:"resource_ids"`
+// 	Mail     string
+// }
+
+type FollowingMapItem struct {
+	Followers   []string `json:"member_ids" db:"member_ids"`
+	ResourceIDs []string `json:"resource_ids" db:"resource_ids"`
+}
+
+type followingAPI struct{}
+
+type FollowingAPIInterface interface {
+	Get(params interface{}) (interface{}, error)
+	Insert(params FollowArgs) error
+	Update(params FollowArgs) error
+	Delete(params FollowArgs) error
+}
+
+func (f *followingAPI) Get(params interface{}) (result interface{}, err error) {
+
+	var rows *sqlx.Rows
+
+	switch params := params.(type) {
+	case *GetFollowingArgs:
+		rows, err = params.get()
+		result, err = params.scan(rows)
+
+	case *GetFollowedArgs:
+		rows, err = params.get()
+		result, err = params.scan(rows)
+
+	case *GetFollowMapArgs:
+		rows, err = params.get()
+		result, err = params.scan(rows)
+	case *GetFollowerMemberIDsArgs:
+		rows, err = params.get()
+		result, err = params.scan(rows)
+	default:
+		return nil, errors.New("None")
+	}
+	return result, err
+}
+
+func (f *followingAPI) Insert(params FollowArgs) (err error) {
+
+	query := `INSERT INTO following_posts (member_id, target_id, type, emotion) VALUES ( ? , ?, ?, ?);`
+
+	result, err := DB.Exec(query, params.Subject, params.Object, params.Type, params.Emotion)
 	if err != nil {
 		sqlerr, ok := err.(*mysql.MySQLError)
 		if ok && sqlerr.Number == 1062 {
@@ -738,18 +364,31 @@ func (f *followingAPI) AddFollowing(params FollowArgs) error {
 	if params.Resource == "post" {
 		go PostCache.UpdateFollowing("follow", params.Subject, params.Object)
 	}
-
 	return nil
 }
 
-func (*followingAPI) DeleteFollowing(params FollowArgs) error {
-	follow, err := CreateFollow(params)
+func (f *followingAPI) Update(params FollowArgs) (err error) {
+
+	result, err := DB.Exec(`UPDATE following SET emotion = ? WHERE member_id = ? AND target_id = ? AND type = ?`, params.Emotion, params.Subject, params.Object, params.Type)
 	if err != nil {
 		log.Println(err.Error())
-		return err
+		return InternalServerError
 	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		log.Println(err.Error())
+		return InternalServerError
+	}
+	if changed == 0 {
+		return SQLUpdateFail
+	}
+	return nil
+}
 
-	_, err = follow.Delete()
+func (f *followingAPI) Delete(params FollowArgs) (err error) {
+
+	query := `DELETE FROM following_posts WHERE member_id = ? AND target_id = ? AND type = ? AND emotion = ?;`
+	_, err = DB.Exec(query, params.Subject, params.Object, params.Type, params.Emotion)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/models/mails.go
+++ b/models/mails.go
@@ -58,11 +58,14 @@ func (m *mailApi) Send(args MailArgs) (err error) {
 
 func (m *mailApi) SendUpdateNote(args GetFollowMapArgs) (err error) {
 
-	followingMap, err := FollowingAPI.GetFollowMap(args)
+	mapInterface, err := FollowingAPI.Get(&args)
 	if err != nil {
 		return err
 	}
-
+	followingMap, ok := mapInterface.([]FollowingMapItem)
+	if !ok {
+		log.Println("Error assert mapInterface @ SendIpdateNote ")
+	}
 	var (
 		follower_index = make(map[string][]string)
 		follower_info  = make(map[string]Member)
@@ -115,9 +118,13 @@ func (m *mailApi) SendUpdateNoteAllResource(args GetFollowMapArgs) (err error) {
 		followers_list []string
 	)
 	for _, t := range []string{"member", "post", "project"} {
-		followingMap, err := FollowingAPI.GetFollowMap(GetFollowMapArgs{Resource: t, UpdateAfter: args.UpdateAfter})
+		mapInterface, err := FollowingAPI.Get(&GetFollowMapArgs{Resource: Resource{ResourceName: t}, UpdateAfter: args.UpdateAfter})
 		if err != nil {
 			return err
+		}
+		followingMap, ok := mapInterface.([]FollowingMapItem)
+		if !ok {
+			log.Println("Error assert mapInterface @ SendIpdateNote ")
 		}
 		for _, m := range followingMap {
 			for _, v := range m.Followers {

--- a/models/types.go
+++ b/models/types.go
@@ -20,6 +20,7 @@ var (
 	MultipleRowAffectedError = errors.New("More Than One Rows Affected")
 
 	SQLInsertionFail = errors.New("SQL Insertion Fail")
+	SQLUpdateFail    = errors.New("SQL Update Fail")
 )
 
 type sqlfields []string

--- a/routes/comment_test.go
+++ b/routes/comment_test.go
@@ -141,7 +141,7 @@ func TestRouteComments(t *testing.T) {
 		models.FollowArgs{Resource: "post", Subject: 91, Object: 92},
 		models.FollowArgs{Resource: "project", Subject: 91, Object: 920},
 	} {
-		err := models.FollowingAPI.AddFollowing(params)
+		err := models.FollowingAPI.Insert(params)
 		if err != nil {
 			log.Printf("Init test case fail. Error: %v", err)
 		}
@@ -347,7 +347,7 @@ func TestPubsubComments(t *testing.T) {
 		models.FollowArgs{Resource: "post", Subject: 91, Object: 92},
 		models.FollowArgs{Resource: "project", Subject: 91, Object: 920},
 	} {
-		err := models.FollowingAPI.AddFollowing(params)
+		err := models.FollowingAPI.Insert(params)
 		if err != nil {
 			log.Printf("Init test case fail. Error: %v", err)
 		}
@@ -394,7 +394,7 @@ func TestPubsubComments(t *testing.T) {
 		models.FollowArgs{Resource: "post", Subject: 91, Object: 92},
 		models.FollowArgs{Resource: "project", Subject: 91, Object: 920},
 	} {
-		err := models.FollowingAPI.DeleteFollowing(params)
+		err := models.FollowingAPI.Delete(params)
 		if err != nil {
 			log.Printf("Init test case fail. Error: %v", err)
 		}

--- a/routes/follow_test.go
+++ b/routes/follow_test.go
@@ -1,15 +1,11 @@
 package routes
 
 import (
-	"bytes"
 	"errors"
-	"log"
 	"testing"
 	"time"
 
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 
 	"github.com/readr-media/readr-restful/models"
 )
@@ -27,7 +23,25 @@ var mockFollowingDS = map[string][]followDS{
 	"project": []followDS{},
 }
 
-func (a *mockFollowingAPI) AddFollowing(params models.FollowArgs) error {
+func (a *mockFollowingAPI) Get(params interface{}) (result interface{}, err error) {
+
+	switch params := params.(type) {
+	case *models.GetFollowingArgs:
+		result, err = getFollowing(params)
+	case *models.GetFollowedArgs:
+		result, err = getFollowed(params)
+	case *models.GetFollowMapArgs:
+		result, err = getFollowMap(params)
+	case *models.GetFollowerMemberIDsArgs:
+		result, err = getFollowerMemberIDs(params)
+	default:
+		return nil, errors.New("Unsupported Query Args")
+	}
+	return result, err
+}
+
+func (a *mockFollowingAPI) Insert(params models.FollowArgs) error {
+
 	store, ok := mockFollowingDS[params.Resource]
 	if !ok {
 		return errors.New("Resource Not Supported")
@@ -36,12 +50,17 @@ func (a *mockFollowingAPI) AddFollowing(params models.FollowArgs) error {
 	store = append(store, followDS{ID: params.Subject, Object: params.Object})
 	return nil
 }
-func (a *mockFollowingAPI) DeleteFollowing(params models.FollowArgs) error {
+
+func (a *mockFollowingAPI) Update(params models.FollowArgs) error {
+	return nil
+}
+
+func (a *mockFollowingAPI) Delete(params models.FollowArgs) error {
+
 	store, ok := mockFollowingDS[params.Resource]
 	if !ok {
 		return errors.New("Resource Not Supported")
 	}
-
 	for index, follow := range store {
 		if follow.ID == params.Subject && follow.Object == params.Object {
 			store = append(store[:index], store[index+1:]...)
@@ -49,17 +68,17 @@ func (a *mockFollowingAPI) DeleteFollowing(params models.FollowArgs) error {
 	}
 	return nil
 }
-func (a *mockFollowingAPI) GetFollowing(params models.GetFollowingArgs) (followings []interface{}, err error) {
 
+func getFollowing(params *models.GetFollowingArgs) (followings []interface{}, err error) {
 	switch {
-	case params.MemberId == 0:
+	case params.MemberID == 0:
 		return nil, errors.New("Not Found")
-	case params.Resource == "member":
+	case params.ResourceName == "member":
 		return []interface{}{
 			models.Member{ID: 72, MemberID: "followtest2@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest2@mirrormedia.mg", true}, Points: models.NullInt{0, true}},
 		}, nil
-	case params.Resource == "post":
-		switch params.Type {
+	case params.ResourceName == "post":
+		switch params.ResourceType {
 		case "":
 			return []interface{}{
 				models.Post{ID: 42, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{71, true}, PublishStatus: models.NullInt{2, true}},
@@ -74,7 +93,7 @@ func (a *mockFollowingAPI) GetFollowing(params models.GetFollowingArgs) (followi
 				models.Post{ID: 84, Active: models.NullInt{1, true}, Type: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{72, true}, PublishStatus: models.NullInt{2, true}},
 			}, nil
 		}
-	case params.Resource == "project":
+	case params.ResourceName == "project":
 		return []interface{}{
 			models.Project{ID: 420, PostID: 42, Active: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2015, time.November, 10, 23, 0, 0, 0, time.UTC), true}, PublishStatus: models.NullInt{2, true}},
 		}, nil
@@ -83,22 +102,23 @@ func (a *mockFollowingAPI) GetFollowing(params models.GetFollowingArgs) (followi
 	}
 	return nil, nil
 }
-func (a *mockFollowingAPI) GetFollowed(args models.GetFollowedArgs) (interface{}, error) {
+
+func getFollowed(args *models.GetFollowedArgs) (interface{}, error) {
 	type followedCount struct {
 		Resourceid int
 		Count      int
 		Follower   []int
 	}
 	switch {
-	case args.Ids[0] == "1001":
+	case args.IDs[0] == 1001:
 		return []followedCount{}, nil
-	case args.Resource == "member":
+	case args.ResourceName == "member":
 		return []followedCount{
 			followedCount{71, 1, []int{72}},
 			followedCount{72, 1, []int{71}},
 		}, nil
-	case args.Resource == "post":
-		switch args.Type {
+	case args.ResourceName == "post":
+		switch args.ResourceType {
 		case "":
 			return []followedCount{
 				followedCount{42, 2, []int{71, 72}},
@@ -114,8 +134,8 @@ func (a *mockFollowingAPI) GetFollowed(args models.GetFollowedArgs) (interface{}
 			}, nil
 		}
 		return nil, nil
-	case args.Resource == "project":
-		switch len(args.Ids) {
+	case args.ResourceName == "project":
+		switch len(args.IDs) {
 		case 1:
 			return []followedCount{
 				followedCount{840, 1, []int{72}},
@@ -131,18 +151,21 @@ func (a *mockFollowingAPI) GetFollowed(args models.GetFollowedArgs) (interface{}
 		return nil, nil
 	}
 }
-func (*mockFollowingAPI) GetFollowerMemberIDs(resourceType string, id string) ([]int, error) {
+
+func getFollowerMemberIDs(args *models.GetFollowerMemberIDsArgs) ([]int, error) {
 	return []int{}, nil
 }
-func (*mockFollowingAPI) GetFollowMap(args models.GetFollowMapArgs) (list []models.FollowingMapItem, err error) {
+
+func getFollowMap(args *models.GetFollowMapArgs) (list []models.FollowingMapItem, err error) {
+
 	switch {
-	case args.Resource == "member":
+	case args.ResourceName == "member":
 		return []models.FollowingMapItem{
 			models.FollowingMapItem{[]string{"72"}, []string{"42"}},
 			models.FollowingMapItem{[]string{"71"}, []string{"84"}},
 		}, nil
-	case args.Resource == "post":
-		switch args.Type {
+	case args.ResourceName == "post":
+		switch args.ResourceType {
 		case "":
 			return []models.FollowingMapItem{
 				models.FollowingMapItem{[]string{"72"}, []string{"42"}},
@@ -158,7 +181,7 @@ func (*mockFollowingAPI) GetFollowMap(args models.GetFollowMapArgs) (list []mode
 			}, nil
 		}
 		return []models.FollowingMapItem{}, nil
-	case args.Resource == "project":
+	case args.ResourceName == "project":
 		return []models.FollowingMapItem{
 			models.FollowingMapItem{[]string{"71"}, []string{"420"}},
 			models.FollowingMapItem{[]string{"72"}, []string{"420", "840"}},
@@ -168,307 +191,151 @@ func (*mockFollowingAPI) GetFollowMap(args models.GetFollowMapArgs) (list []mode
 	}
 }
 
-func initFollowTest() {
-	mockPostDSBack = mockPostDS
+// func initFollowTest() {
+// 	mockPostDSBack = mockPostDS
 
-	for _, params := range []models.Member{
-		models.Member{ID: 70, MemberID: "followtest0@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest0@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b88e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b58e-f06e59fd8467", true}},
-		models.Member{ID: 71, MemberID: "followtest1@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest1@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b59e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b59e-f06e59fd8467", true}},
-		models.Member{ID: 72, MemberID: "followtest2@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest2@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b60e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b60e-f06e59fd8467", true}},
-	} {
-		_, err := models.MemberAPI.InsertMember(params)
-		if err != nil {
-			log.Printf("Insert member fail when init test case. Error: %v", err)
-		}
-	}
+// 	for _, params := range []models.Member{
+// 		models.Member{ID: 70, MemberID: "followtest0@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest0@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b88e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b58e-f06e59fd8467", true}},
+// 		models.Member{ID: 71, MemberID: "followtest1@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest1@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b59e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b59e-f06e59fd8467", true}},
+// 		models.Member{ID: 72, MemberID: "followtest2@mirrormedia.mg", Active: models.NullInt{1, true}, PostPush: models.NullBool{true, true}, UpdatedAt: models.NullTime{time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Mail: models.NullString{"followtest2@mirrormedia.mg", true}, Points: models.NullInt{0, true}, UUID: "abc1d5b1-da54-4200-b60e-f06e59fd8467", TalkID: models.NullString{"abc1d5b1-da54-4200-b60e-f06e59fd8467", true}},
+// 	} {
+// 		_, err := models.MemberAPI.InsertMember(params)
+// 		if err != nil {
+// 			log.Printf("Insert member fail when init test case. Error: %v", err)
+// 		}
+// 	}
 
-	for _, params := range []models.Post{
-		models.Post{ID: 42, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{71, true}, PublishStatus: models.NullInt{2, true}},
-		models.Post{ID: 84, Active: models.NullInt{1, true}, Type: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{72, true}, PublishStatus: models.NullInt{2, true}},
-	} {
-		_, err := models.PostAPI.InsertPost(params)
-		if err != nil {
-			log.Printf("Insert post fail when init test case. Error: %v", err)
-		}
-	}
+// 	for _, params := range []models.Post{
+// 		models.Post{ID: 42, Active: models.NullInt{1, true}, Type: models.NullInt{0, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{71, true}, PublishStatus: models.NullInt{2, true}},
+// 		models.Post{ID: 84, Active: models.NullInt{1, true}, Type: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC), true}, Author: models.NullInt{72, true}, PublishStatus: models.NullInt{2, true}},
+// 	} {
+// 		_, err := models.PostAPI.InsertPost(params)
+// 		if err != nil {
+// 			log.Printf("Insert post fail when init test case. Error: %v", err)
+// 		}
+// 	}
 
-	for _, params := range []models.Project{
-		models.Project{ID: 420, PostID: 42, Active: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2015, time.November, 10, 23, 0, 0, 0, time.UTC), true}, PublishStatus: models.NullInt{2, true}},
-		models.Project{ID: 840, PostID: 84, Active: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2016, time.November, 10, 23, 0, 0, 0, time.UTC), true}, PublishStatus: models.NullInt{2, true}},
-	} {
-		err := models.ProjectAPI.InsertProject(params)
-		if err != nil {
-			log.Printf("Insert Project fail when init test case. Error: %v", err)
-		}
-	}
+// 	for _, params := range []models.Project{
+// 		models.Project{ID: 420, PostID: 42, Active: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2015, time.November, 10, 23, 0, 0, 0, time.UTC), true}, PublishStatus: models.NullInt{2, true}},
+// 		models.Project{ID: 840, PostID: 84, Active: models.NullInt{1, true}, UpdatedAt: models.NullTime{time.Date(2016, time.November, 10, 23, 0, 0, 0, time.UTC), true}, PublishStatus: models.NullInt{2, true}},
+// 	} {
+// 		err := models.ProjectAPI.InsertProject(params)
+// 		if err != nil {
+// 			log.Printf("Insert Project fail when init test case. Error: %v", err)
+// 		}
+// 	}
 
-	for _, params := range []models.FollowArgs{
-		models.FollowArgs{Resource: "member", Subject: 71, Object: 72},
-		models.FollowArgs{Resource: "post", Subject: 71, Object: 42},
-		models.FollowArgs{Resource: "post", Subject: 71, Object: 84},
-		models.FollowArgs{Resource: "project", Subject: 71, Object: 420},
-		models.FollowArgs{Resource: "member", Subject: 72, Object: 71},
-		models.FollowArgs{Resource: "post", Subject: 72, Object: 42},
-		models.FollowArgs{Resource: "project", Subject: 72, Object: 420},
-		models.FollowArgs{Resource: "project", Subject: 72, Object: 840},
-	} {
-		err := models.FollowingAPI.AddFollowing(params)
-		if err != nil {
-			log.Printf("Init test case fail. Error: %v", err)
-		}
-	}
-}
+// 	for _, params := range []models.FollowArgs{
+// 		models.FollowArgs{Resource: "member", Subject: 71, Object: 72},
+// 		models.FollowArgs{Resource: "post", Subject: 71, Object: 42},
+// 		models.FollowArgs{Resource: "post", Subject: 71, Object: 84},
+// 		models.FollowArgs{Resource: "project", Subject: 71, Object: 420},
+// 		models.FollowArgs{Resource: "member", Subject: 72, Object: 71},
+// 		models.FollowArgs{Resource: "post", Subject: 72, Object: 42},
+// 		models.FollowArgs{Resource: "project", Subject: 72, Object: 420},
+// 		models.FollowArgs{Resource: "project", Subject: 72, Object: 840},
+// 	} {
+// 		err := models.FollowingAPI.Insert(params)
+// 		if err != nil {
+// 			log.Printf("Init test case fail. Error: %v", err)
+// 		}
+// 	}
+// }
 
-func clearFollowTest() {
-	//restore the backuped data
-	mockPostDS = mockPostDSBack
-}
+// {"GetFollowingPostOK", CaseIn{"post", "", 71}, CaseOut{http.StatusOK, `[{"id":42,"author":71,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":0,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2},{"id":84,"author":72,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":1,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
+// {"GetFollowingPostReviewOK", CaseIn{"post", "review", 71}, CaseOut{http.StatusOK, `[{"id":42,"author":71,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":0,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
+// {"GetFollowingPostNewsOK", CaseIn{"post", "news", 71}, CaseOut{http.StatusOK, `[{"id":84,"author":72,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":1,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
+// {"GetFollowingProjectOK", CaseIn{"project", "", 71}, CaseOut{http.StatusOK, `[{"id":420,"created_at":null,"updated_at":"2015-11-10T23:00:00Z","updated_by":null,"published_at":null,"post_id":42,"like_amount":null,"comment_amount":null,"active":1,"hero_image":null,"title":null,"description":null,"author":null,"og_title":null,"og_description":null,"og_image":null,"project_order":null,"status":null,"slug":null,"views":null,"publish_status":2,"progress":null,"memo_points":null}]`}},
+// {"GetFollowingFollowerNotExist", CaseIn{"project", "", 0}, CaseOut{http.StatusOK, `[]`}},
 
-func TestFollowingGet(t *testing.T) {
+// {"GetFollowedPostOK", CaseIn{"post", "", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":42,"Count":2,"Follower":[71,72]},{"Resourceid":84,"Count":1,"Follower":[71]}]`}},
+// {"GetFollowedPostReviewOK", CaseIn{"post", "review", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":42,"Count":2,"Follower":[71,72]}]`}},
+// {"GetFollowedPostNewsOK", CaseIn{"post", "news", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":84,"Count":1,"Follower":[71]}]`}},
+// {"GetFollowedMemberOK", CaseIn{"member", "", []string{"71", "72"}}, CaseOut{http.StatusOK, `[{"Resourceid":71,"Count":1,"Follower":[72]},{"Resourceid":72,"Count":1,"Follower":[71]}]`}},
+// {"GetFollowedProjectSingleOK", CaseIn{"project", "", []string{"840"}}, CaseOut{http.StatusOK, `[{"Resourceid":840,"Count":1,"Follower":[72]}]`}},
+// {"GetFollowedProjectOK", CaseIn{"project", "", []string{"420", "840"}}, CaseOut{http.StatusOK, `[{"Resourceid":420,"Count":2,"Follower":[71,72]},{"Resourceid":840,"Count":1,"Follower":[72]}]`}},
+// {"GetFollowedMissingResource", CaseIn{"", "", []string{"420", "840"}}, CaseOut{http.StatusBadRequest, `{"Error":"Unsupported Resource"}`}},
+// {"GetFollowedMissingID", CaseIn{"post", "", []string{}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
+// {"GetFollowedPostNotExist", CaseIn{"post", "", []string{"1001", "1000"}}, CaseOut{http.StatusOK, `[]`}},
+// {"GetFollowedPostStringID", CaseIn{"post", "", []string{"unintegerable"}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
+// {"GetFollowedProjectStringID", CaseIn{"project", "", []string{"unintegerable"}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
 
-	initFollowTest()
+// {"GetFollowMapPostOK", CaseIn{"post", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["72"],"resource_ids":["42"]},{"member_ids":["71"],"resource_ids":["42","84"]}],"resource":"post"}`}},
+// {"GetFollowMapPostReviewOK", CaseIn{"post", "review", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71","72"],"resource_ids":["42"]}],"resource":"post"}`}},
+// {"GetFollowMapPostNewsOK", CaseIn{"post", "news", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71"],"resource_ids":["84"]}],"resource":"post"}`}},
+// {"GetFollowMapResourceUnknown", CaseIn{"unknown source", "news", time.Time{}}, CaseOut{http.StatusBadRequest, `{"Error":"Resource Not Supported"}`}},
+// {"GetFollowMapMemberOK", CaseIn{"member", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["72"],"resource_ids":["42"]},{"member_ids":["71"],"resource_ids":["84"]}],"resource":"member"}`}},
+// {"GetFollowMapProjectOK", CaseIn{"project", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71"],"resource_ids":["420"]},{"member_ids":["72"],"resource_ids":["420","840"]}],"resource":"project"}`}},
 
-	type CaseIn struct {
-		Resource     string `json:"resource,omitempty"`
-		ResourceType string `json:"resource_type, omitempty"`
-		Subject      int64  `json:"subject,omitempty"`
-	}
+func TestFollowing(t *testing.T) {
 
-	type CaseOut struct {
-		httpcode int
-		resp     string
-	}
-
-	var TestRouteName = "/following/byuser"
-	var TestRouteMethod = "GET"
-
-	var TestFollowingGetCases = []struct {
-		name string
-		in   CaseIn
-		out  CaseOut
-	}{
-		{"GetFollowingPostOK", CaseIn{"post", "", 71}, CaseOut{http.StatusOK, `[{"id":42,"author":71,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":0,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2},{"id":84,"author":72,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":1,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
-		{"GetFollowingPostReviewOK", CaseIn{"post", "review", 71}, CaseOut{http.StatusOK, `[{"id":42,"author":71,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":0,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
-		{"GetFollowingPostNewsOK", CaseIn{"post", "news", 71}, CaseOut{http.StatusOK, `[{"id":84,"author":72,"created_at":null,"like_amount":null,"comment_amount":null,"title":null,"content":null,"type":1,"link":null,"og_title":null,"og_description":null,"og_image":null,"active":1,"updated_at":"2009-11-10T23:00:00Z","updated_by":null,"published_at":null,"link_title":null,"link_description":null,"link_image":null,"link_name":null,"video_id":null,"video_views":null,"publish_status":2}]`}},
-		{"GetFollowingProjectOK", CaseIn{"project", "", 71}, CaseOut{http.StatusOK, `[{"id":420,"created_at":null,"updated_at":"2015-11-10T23:00:00Z","updated_by":null,"published_at":null,"post_id":42,"like_amount":null,"comment_amount":null,"active":1,"hero_image":null,"title":null,"description":null,"author":null,"og_title":null,"og_description":null,"og_image":null,"project_order":null,"status":null,"slug":null,"views":null,"publish_status":2,"progress":null,"memo_points":null}]`}},
-		{"GetFollowingFollowerNotExist", CaseIn{"project", "", 0}, CaseOut{http.StatusOK, `[]`}},
-	}
-
-	for _, testcase := range TestFollowingGetCases {
-
-		jsonStr, err := json.Marshal(&testcase.in)
-		if err != nil {
-			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
-			t.Fail()
+	transformPubsub := func(tc genericTestcase) genericTestcase {
+		meta := PubsubMessageMeta{
+			Subscription: "sub",
+			Message: PubsubMessageMetaBody{
+				ID:   "1",
+				Body: []byte(tc.body.(string)),
+				Attr: map[string]string{"type": "follow", "action": tc.method},
+			},
 		}
 
-		req, _ := http.NewRequest(TestRouteMethod, TestRouteName, bytes.NewBuffer(jsonStr))
-		req.Header.Set("Content-Type", "application/json")
+		return genericTestcase{tc.name, "POST", "/restful/pubsub", meta, tc.httpcode, tc.resp}
+	}
 
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
+	t.Run("Get", func(t *testing.T) {
 
-		if w.Code != testcase.out.httpcode {
-			t.Errorf("Want %d but get %d, testcase %s", testcase.out.httpcode, w.Code, testcase.name)
-			t.Fail()
+		for _, testcase := range []genericTestcase{
+
+			// Only check error message when http status != 200
+			// use nil as resp parameter for genericDoTest()
+			genericTestcase{"FollowingPostOK", "GET", `/following/user?resource=post&id=71`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowingPostReviewOK", "GET", `/following/user?resource=post&resource_type=review&id=71`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowingPostNewsOK", "GET", `/following/user?resource=post&resource_type=news&id=71`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowingProjectOK", "GET", `/following/user?resource=project&id=71`, ``, http.StatusOK, nil},
+
+			genericTestcase{"FollowedPostOK", "GET", `/following/resource?resource=post&ids=[42,84]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedPostReviewOK", "GET", `/following/resource?resource=post&ids=[42,84]&resource_type=review`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedPostNewsOK", "GET", `/following/resource?resource=post&resource_type=news&ids=[42,84]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedMemberOK", "GET", `/following/resource?resource=member&ids=[42,84]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedProjectSingleOK", "GET", `/following/resource?resource=project&ids=[840]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedProjectOK", "GET", `/following/resource?resource=project&ids=[420,840]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedMissingResource", "GET", `/following/resource?ids=[420,840]`, ``, http.StatusBadRequest, `{"Error":"Unsupported Resource"}`},
+			genericTestcase{"FollowedMissingID", "GET", `/following/resource?resource=post&ids=[]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
+			genericTestcase{"FollowedPostNotExist", "GET", `/following/resource?resource=post&ids=[1000,1001]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowedPostStringID", "GET", `/following/resource?resourcea=post&ids=[unintegerable]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
+			genericTestcase{"FollowedProjectStringID", "GET", `/following/resource?resource=project&ids=[unintegerable]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
+
+			genericTestcase{"FollowMapPostOK", "GET", `/following/map?resource=post`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowMapPostReviewOK", "GET", `/following/map?resource=post&resource_type=review`, ``, http.StatusOK, nil},
+			genericTestcase{"GetFollowMapPostNewsOK", "GET", `/following/map?resource=post&resource_type=news`, ``, http.StatusOK, nil},
+			genericTestcase{"GetFollowMapResourceUnknown", "GET", `/following/map?resource=unknown source&resource_type=news`, ``, http.StatusBadRequest, `{"Error":"Unsupported Resource"}`},
+			genericTestcase{"GetFollowMapMemberOK", "GET", `/following/map?resource=member`, ``, http.StatusOK, nil},
+			genericTestcase{"GetFollowMapProjectOK", "GET", `/following/map?resource=project`, ``, http.StatusOK, nil},
+		} {
+			genericDoTest(testcase, t, nil)
 		}
+	})
+	// It seems insert and delete shouldn't be tested here.
+	t.Run("Insert", func(t *testing.T) {
 
-		if w.Body.String() != testcase.out.resp {
-			t.Errorf("Expect get error message %v but get %v, testcase %s", testcase.out.resp, w.Body.String(), testcase.name)
-			t.Fail()
+		for _, testcase := range []genericTestcase{
+			genericTestcase{"FollowingPostOK", "follow", `/restful/pubsub`, `{"resource":"member","subject":70,"object":84}`, http.StatusOK, nil},
+			genericTestcase{"FollowingMemberOK", "follow", `/restful/pubsub`, `{"resource":"member","subject":70,"object":72}`, http.StatusOK, nil},
+			genericTestcase{"FollowingProjectOK", "follow", `/restful/pubsub`, `{"resource":"project","subject":70,"object":840}`, http.StatusOK, nil},
+			genericTestcase{"FollowingMissingResource", "follow", `/restful/pubsub`, `{"resource":"","subject":70,"object":72}`, http.StatusOK, `{"Error":"Resource Not Supported"}`},
+			genericTestcase{"FollowingMissingAction", "", `/restful/pubsub`, `{"resource":"","subject":70,"object":72}`, http.StatusOK, `{"Error":"Bad Request"}`},
+		} {
+			genericDoTest(transformPubsub(testcase), t, nil)
 		}
+	})
+	t.Run("Delete", func(t *testing.T) {
 
-	}
-
-	clearFollowTest()
-}
-
-func TestFollowedGet(t *testing.T) {
-
-	type CaseIn struct {
-		ResourceName string   `json:"resource",omitempty`
-		ResourceType string   `json:"resource_type",omitempty`
-		ResourceId   []string `json:"ids",omitempty`
-	}
-
-	type CaseOut struct {
-		httpcode int
-		resp     string
-	}
-
-	var TestRouteName = "/following/byresource"
-	var TestRouteMethod = "GET"
-
-	var TestFollowingGetCases = []struct {
-		name string
-		in   CaseIn
-		out  CaseOut
-	}{
-		{"GetFollowedPostOK", CaseIn{"post", "", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":42,"Count":2,"Follower":[71,72]},{"Resourceid":84,"Count":1,"Follower":[71]}]`}},
-		{"GetFollowedPostReviewOK", CaseIn{"post", "review", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":42,"Count":2,"Follower":[71,72]}]`}},
-		{"GetFollowedPostNewsOK", CaseIn{"post", "news", []string{"42", "84"}}, CaseOut{http.StatusOK, `[{"Resourceid":84,"Count":1,"Follower":[71]}]`}},
-		{"GetFollowedMemberOK", CaseIn{"member", "", []string{"71", "72"}}, CaseOut{http.StatusOK, `[{"Resourceid":71,"Count":1,"Follower":[72]},{"Resourceid":72,"Count":1,"Follower":[71]}]`}},
-		{"GetFollowedProjectSingleOK", CaseIn{"project", "", []string{"840"}}, CaseOut{http.StatusOK, `[{"Resourceid":840,"Count":1,"Follower":[72]}]`}},
-		{"GetFollowedProjectOK", CaseIn{"project", "", []string{"420", "840"}}, CaseOut{http.StatusOK, `[{"Resourceid":420,"Count":2,"Follower":[71,72]},{"Resourceid":840,"Count":1,"Follower":[72]}]`}},
-		{"GetFollowedMissingResource", CaseIn{"", "", []string{"420", "840"}}, CaseOut{http.StatusBadRequest, `{"Error":"Unsupported Resource"}`}},
-		{"GetFollowedMissingID", CaseIn{"post", "", []string{}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
-		{"GetFollowedPostNotExist", CaseIn{"post", "", []string{"1001", "1000"}}, CaseOut{http.StatusOK, `[]`}},
-		{"GetFollowedPostStringID", CaseIn{"post", "", []string{"unintegerable"}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
-		{"GetFollowedProjectStringID", CaseIn{"project", "", []string{"unintegerable"}}, CaseOut{http.StatusBadRequest, `{"Error":"Bad Resource ID"}`}},
-	}
-
-	for _, testcase := range TestFollowingGetCases {
-
-		jsonStr, err := json.Marshal(&testcase.in)
-		if err != nil {
-			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
-			t.Fail()
+		for _, testcase := range []genericTestcase{
+			genericTestcase{"FollowingPostOK", "unfollow", `/restful/pubsub`, `{"resource":"post","subject":70,"object":84}`, http.StatusOK, nil},
+			genericTestcase{"FollowingMemberOK", "unfollow", `/restful/pubsub`, `{"resource":"member","subject":70,"object":72}`, http.StatusOK, nil},
+			genericTestcase{"FollowingProjectOK", "unfollow", `/restful/pubsub`, `{"resource":"project","subject":70,"object":840}`, http.StatusOK, nil},
+		} {
+			genericDoTest(transformPubsub(testcase), t, nil)
 		}
-
-		req, _ := http.NewRequest(TestRouteMethod, TestRouteName, bytes.NewBuffer(jsonStr))
-		req.Header.Set("Content-Type", "application/json")
-
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-
-		if w.Code != testcase.out.httpcode {
-			t.Errorf("Want %d but get %d, testcase %s", testcase.out.httpcode, w.Code, testcase.name)
-			t.Fail()
-		}
-
-		if w.Body.String() != testcase.out.resp {
-			t.Errorf("Expect get error message %v but get %v, testcase %s", testcase.out.resp, w.Body.String(), testcase.name)
-			t.Fail()
-		}
-	}
-
-	clearFollowTest()
-}
-
-func TestFollowMap(t *testing.T) {
-
-	type CaseIn struct {
-		ResourceName string    `json:"resource",omitempty`
-		ResourceType string    `json:"resource_type",omitempty`
-		UpdatedAfter time.Time `json:"updated_after",omitempty`
-	}
-
-	type CaseOut struct {
-		httpcode int
-		resp     string
-	}
-
-	var TestRouteName = "/following/map"
-	var TestRouteMethod = "GET"
-
-	var TestFollowingGetCases = []struct {
-		name string
-		in   CaseIn
-		out  CaseOut
-	}{
-		{"GetFollowMapPostOK", CaseIn{"post", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["72"],"resource_ids":["42"]},{"member_ids":["71"],"resource_ids":["42","84"]}],"resource":"post"}`}},
-		{"GetFollowMapPostReviewOK", CaseIn{"post", "review", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71","72"],"resource_ids":["42"]}],"resource":"post"}`}},
-		{"GetFollowMapPostNewsOK", CaseIn{"post", "news", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71"],"resource_ids":["84"]}],"resource":"post"}`}},
-		{"GetFollowMapResourceUnknown", CaseIn{"unknown source", "news", time.Time{}}, CaseOut{http.StatusBadRequest, `{"Error":"Resource Not Supported"}`}},
-		{"GetFollowMapMemberOK", CaseIn{"member", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["72"],"resource_ids":["42"]},{"member_ids":["71"],"resource_ids":["84"]}],"resource":"member"}`}},
-		{"GetFollowMapProjectOK", CaseIn{"project", "", time.Time{}}, CaseOut{http.StatusOK, `{"list":[{"member_ids":["71"],"resource_ids":["420"]},{"member_ids":["72"],"resource_ids":["420","840"]}],"resource":"project"}`}},
-	}
-
-	for _, testcase := range TestFollowingGetCases {
-
-		jsonStr, err := json.Marshal(&testcase.in)
-		if err != nil {
-			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
-			t.Fail()
-		}
-
-		req, _ := http.NewRequest(TestRouteMethod, TestRouteName, bytes.NewBuffer(jsonStr))
-		req.Header.Set("Content-Type", "application/json")
-
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-
-		if w.Code != testcase.out.httpcode {
-			t.Errorf("Want %d but get %d, testcase %s", testcase.out.httpcode, w.Code, testcase.name)
-			t.Fail()
-		}
-
-		if w.Body.String() != testcase.out.resp {
-			t.Errorf("Expect get error message %v but get %v, testcase %s", testcase.out.resp, w.Body.String(), testcase.name)
-			t.Fail()
-		}
-	}
-
-	clearFollowTest()
-}
-
-func TestFollowingAddDelete(t *testing.T) {
-
-	type PubsubWrapperMessage struct {
-		ID   string            `json:"messageId"`
-		Attr map[string]string `json:"attributes"`
-		Body []byte            `json:"data"`
-	}
-
-	type PubsubWrapper struct {
-		Subscription string               `json:"subscription"`
-		Message      PubsubWrapperMessage `json:"message"`
-	}
-
-	type CaseIn struct {
-		Action   string
-		Resource string `json:resource,omitempty`
-		Subject  int    `json:subject,omitempty`
-		Object   int    `json:object,omitempty`
-	}
-
-	type CaseOut struct {
-		httpcode int
-		Error    string
-	}
-
-	var TestRouteName = "/restful/pubsub"
-	var TestRouteMethod = "POST"
-
-	var TestFollowingGetCases = []struct {
-		name string
-		in   CaseIn
-		out  CaseOut
-	}{
-		{"AddFollowingPostOK", CaseIn{"follow", "post", 70, 84}, CaseOut{http.StatusOK, ""}},
-		{"AddFollowingMemberOK", CaseIn{"follow", "member", 70, 72}, CaseOut{http.StatusOK, ""}},
-		{"AddFollowingProjectOK", CaseIn{"follow", "project", 70, 840}, CaseOut{http.StatusOK, ""}},
-		{"AddFollowingMissingResource", CaseIn{"follow", "", 70, 72}, CaseOut{http.StatusOK, `{"Error":"Resource Not Supported"}`}},
-		//{"AddFollowingMissingAction", CaseIn{"follow","", "member", "70", "72"}, CaseOut{http.StatusOK, `{"Error":"Bad Request"}`}},
-		{"DeleteFollowingPostOK", CaseIn{"unfollow", "post", 70, 84}, CaseOut{http.StatusOK, ""}},
-		{"DeleteFollowingMemberOK", CaseIn{"unfollow", "member", 70, 72}, CaseOut{http.StatusOK, ""}},
-		{"DeleteFollowingProjectOK", CaseIn{"unfollow", "project", 70, 840}, CaseOut{http.StatusOK, ""}},
-	}
-
-	for _, testcase := range TestFollowingGetCases {
-		bodyJsonStr, err := json.Marshal(&testcase.in)
-		if err != nil {
-			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
-			t.Fail()
-		}
-
-		jsonStr, err := json.Marshal(&PubsubWrapper{"subs", PubsubWrapperMessage{"1", map[string]string{"type": "follow", "action": testcase.in.Action}, bodyJsonStr}})
-		if err != nil {
-			t.Errorf("Fail to marshal input objects, error: %v", err.Error())
-			t.Fail()
-		}
-
-		req, _ := http.NewRequest(TestRouteMethod, TestRouteName, bytes.NewBuffer(jsonStr))
-		req.Header.Set("Content-Type", "application/json")
-
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-
-		if w.Body.String() != testcase.out.Error {
-			t.Errorf("Expect get error message %v but get %v, testcase %s", testcase.out.Error, w.Body.String(), testcase.name)
-			t.Fail()
-		}
-	}
-
-	clearFollowTest()
+	})
 }

--- a/routes/mail.go
+++ b/routes/mail.go
@@ -41,11 +41,11 @@ func (r *mailHandler) updateNote(c *gin.Context) {
 		return
 	}
 
-	if ok, err := regexp.MatchString("(post|project|member)", args.Resource); args.Resource != "" && (err != nil || !ok) {
+	if ok, err := regexp.MatchString("(post|project|member)", args.ResourceName); args.ResourceName != "" && (err != nil || !ok) {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid Resource"})
 		return
 	}
-	if args.Resource == "" {
+	if args.ResourceName == "" {
 		if err := models.MailAPI.SendUpdateNoteAllResource(args); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return

--- a/routes/pubsub.go
+++ b/routes/pubsub.go
@@ -67,18 +67,18 @@ func (r *pubsubHandler) Push(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"Error": "Bad Request"})
 			return
 		}
-		params := models.FollowArgs{Resource: body.Resource, Subject: int64(body.Subject), Object: int64(body.Object)}
 
+		params := models.FollowArgs{Resource: body.Resource, Subject: int64(body.Subject), Object: int64(body.Object)}
 		switch actionType {
 		case "follow":
-			if err = models.FollowingAPI.AddFollowing(params); err != nil {
+			if err = models.FollowingAPI.Insert(params); err != nil {
 				log.Printf("%s fail: %v \n", actionType, err.Error())
 				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
 				return
 			}
 			c.Status(http.StatusOK)
 		case "unfollow":
-			if err = models.FollowingAPI.DeleteFollowing(params); err != nil {
+			if err = models.FollowingAPI.Delete(params); err != nil {
 				log.Printf("%s fail: %v \n", actionType, err.Error())
 				c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
 				return
@@ -257,6 +257,7 @@ func (r *pubsubHandler) Push(c *gin.Context) {
 
 	default:
 		log.Println("Pubsub Message Type Not Support", actionType)
+		fmt.Println(msgType)
 		c.Status(http.StatusOK)
 		return
 	}


### PR DESCRIPTION
1. Integrated database tables: following_members, following_posts, following_projects
2. Changed ways of receiving argument from using payload to receiving both payload and url parameters
- API entrypoint changed:

`/following/byresource` -> `/following/resource`
`/following/byuser` -> `/following/user`

In this case, json payload `subject` -> `id`. Originally `GET /following/byuser {"subject":648, "resource":"post","type":news"}` now become `GET /following/user {"id":648, "resource":"post","type":news"}`. Alternatively, you could use `GET /following/user?id=648&resource=post&resource_type=news` as well to get the same response.

Everything else remain unchanged. 

- id arguments used to be string, like `ids=["1001","1002"]`, are now all in integer.

- emotion functions are **not** fully implemented **yet**

@tempo0829 

3. Use interface to implement GET method. The API is compatible with old argument structs
4. Included Update(). Following API now have 4 methods: `Get`, `Insert`, `Update`, `Delete`
5. Replaced GetFollowerMemberIDs with Get in **Comments**, **Mail** and **Pubsub** API
6. Modified follow_test
- Adopted genericTestcase
- Only test router correctness. Do not check JSON body unless http code is not expected to be 200
