### PR TITLE
Implemented emotion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ type appConfig struct {
 		Reports               map[string]int `mapstructure:"reports"`
 		ReportsPublishStatus  map[string]int `mapstructure:"reports_publish_status"`
 		FollowingType         map[string]int `mapstructure:"following_type"`
+		Emotions              map[string]int `mapstructure:"emotions"`
 	} `mapstructure:"models"`
 }
 

--- a/config/main_sample.json
+++ b/config/main_sample.json
@@ -111,10 +111,14 @@
         },
         "following_type": {
             "member": 9,
-            "post": 2,
-            "project": 3,
-            "memo": 4,
-            "report": 5
+            "post": 9,
+            "project": 9,
+            "memo": 9,
+            "report": 9
+        },
+        "emotions":{
+            "like": 9,
+            "dislike": 9
         }
     }
 }

--- a/models/follows.go
+++ b/models/follows.go
@@ -106,18 +106,20 @@ func (g *GetFollowingArgs) scan(rows *sqlx.Rows) (interface{}, error) {
 		}
 	}
 
-	if len(followings) == 0 {
-		err = errors.New("Not Found")
-	}
+	// if len(followings) == 0 {
+	// 	err = errors.New("Not Found")
+	// }
 	return followings, err
 }
 
 type GetFollowedArgs struct {
-	IDs []int64 `json:"ids"`
+	IDs     []int64 `json:"ids"`
+	Emotion int
 	Resource
 }
 
 func (g *GetFollowedArgs) get() (*sqlx.Rows, error) {
+
 	var osql = struct {
 		base      string
 		condition []string
@@ -140,6 +142,10 @@ func (g *GetFollowedArgs) get() (*sqlx.Rows, error) {
 			// osql.args = append(osql.args, int(t.(float64)))
 			osql.args = append(osql.args, t)
 		}
+	}
+	if g.Emotion > 0 {
+		osql.condition = append(osql.condition, "f.emotion = ?")
+		osql.args = append(osql.args, g.Emotion)
 	}
 
 	query, args, err := sqlx.In(fmt.Sprintf(osql.base, strings.Join(osql.join, " LEFT JOIN "), strings.Join(osql.condition, " AND ")), osql.args...)
@@ -342,7 +348,7 @@ func (f *followingAPI) Get(params interface{}) (result interface{}, err error) {
 		rows, err = params.get()
 		result, err = params.scan(rows)
 	default:
-		return nil, errors.New("None")
+		return nil, errors.New("Bad Request")
 	}
 	return result, err
 }

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -107,6 +107,15 @@ func bindFollow(c *gin.Context) (result interface{}, err error) {
 		if len(params.IDs) == 0 {
 			return nil, errors.New("Bad Resource ID")
 		}
+		// If there is valid emotion parameter, return emotion rather than follow
+		if c.Query("emotion") != "" {
+			if val, ok := config.Config.Models.Emotions[c.Query("emotion")]; ok {
+				params.FollowType = 0
+				params.Emotion = val
+			} else {
+				return nil, errors.New("Unsupported Emotion")
+			}
+		}
 		result = params
 	case "map":
 		var params = &models.GetFollowMapArgs{}


### PR DESCRIPTION
1. Completed Pub/Sub mechanism for insert, update, and delete emotion
- type: `emotion`
Set "type":"emotion" in PubSub

- action: `insert`, `update`, or `delete`
Set "action" in one of the above three actions

- resouce: `like` or `dislike`
Set "resource":"like" or "dislike"
Others remain the same as in follow

For example, to insert a like for member `648` and object `506`
use
```bash
customAttrs
{
	type: 'emotion',
}

dataBuffer
{
	action: 'insert',
	resource: 'like',
	subject: 648,
	object: 506
}
```

2. When there is no match result for `/user` endpoint, return http 200 and `{"_items":null}`
3. `Get /resource` support emotion parameter
To restrict emotion to **like**, pass `emotion=like`
`GET /resource?emotion=like`

**Temporarily emotion parameter will invalidate `resource` parameter**