### PR TITLE
Revised API for /members/nickname

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -35,6 +35,7 @@ type PointsArgs struct {
 	MaxResult uint8  `form:"max_result"`
 	Page      uint16 `form:"page"`
 	OrderBy   string `form:"sort"`
+	PayType   string `form:"pay_type"`
 
 	OSQL
 }
@@ -76,6 +77,13 @@ func (a *PointsArgs) build() {
 			a.args = append(a.args, a.ObjectIDs[i])
 		}
 		a.conditions = append(a.conditions, fmt.Sprintf("pts.object_id IN (%s)", strings.Join(ph, ",")))
+	}
+	if a.PayType != "" {
+		if a.PayType == "topup" {
+			a.conditions = append(a.conditions, "pts.points < 0")
+		} else if a.PayType == "consumption" {
+			a.conditions = append(a.conditions, "pts.points > 0")
+		}
 	}
 	if len(a.conditions) > 0 {
 		a.query = fmt.Sprintf("%s WHERE %s", a.query, strings.Join(a.conditions, " AND "))

--- a/routes/member_test.go
+++ b/routes/member_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"testing"
@@ -202,13 +201,16 @@ func (a *mockMemberAPI) Count(req *models.MemberArgs) (result int, err error) {
 	return result, err
 }
 
-func (a *mockMemberAPI) GetIDsByNickname(key string, roles map[string][]int) (result []models.NicknameID, err error) {
-	for _, v := range mockMemberDS {
-		if v.Nickname.Valid {
-			if matched, err := regexp.MatchString(key, v.Nickname.String); err == nil && matched {
-				result = append(result, models.NicknameID{ID: v.ID, Nickname: v.Nickname})
-			}
+func (a *mockMemberAPI) GetIDsByNickname(params models.GetMembersKeywordsArgs) (result []models.Stunt, err error) {
+	if params.Keywords == "readr" {
+		if params.Roles != nil {
+			result = append(result, models.Stunt{ID: &(mockMemberDS[0].ID), Nickname: &(mockMemberDS[0].Nickname)},
+				models.Stunt{ID: &(mockMemberDS[1].ID), Nickname: &(mockMemberDS[1].Nickname)})
+			return result, err
 		}
+		result = append(result, models.Stunt{ID: &(mockMemberDS[0].ID), Nickname: &(mockMemberDS[0].Nickname)})
+		return result, err
+
 	}
 	return result, err
 }
@@ -306,8 +308,9 @@ func TestRouteMembers(t *testing.T) {
 	t.Run("KeyNickname", func(t *testing.T) {
 		for _, testcase := range []genericTestcase{
 			genericTestcase{"Keyword", "GET", `/members/nickname?keyword=readr`, ``, http.StatusOK, `{"_items":[{"id":1,"nickname":"readr"}]}`},
-			genericTestcase{"KeywordAndRoles", "GET", `/members/nickname?keyword=readr&roles={"$in":[3,9]}`, ``, http.StatusOK, `{"_items":[{"id":1,"nickname":"readr"}]}`},
+			genericTestcase{"KeywordAndRoles", "GET", `/members/nickname?keyword=readr&roles={"$in":[3,9]}`, ``, http.StatusOK, `{"_items":[{"id":1,"nickname":"readr"},{"id":2,"nickname":"yeahyeahyeah"}]}`},
 			genericTestcase{"InvalidKeyword", "GET", `/members/nickname`, ``, http.StatusBadRequest, `{"Error":"Invalid keyword"}`},
+			genericTestcase{"InvalidFields", "GET", `/members/nickname?keyword=readr&fields=["line"]`, ``, http.StatusBadRequest, `{"Error":"Invalid fields: line"}`},
 		} {
 			genericDoTest(testcase, t, asserter)
 		}

--- a/routes/points.go
+++ b/routes/points.go
@@ -14,7 +14,7 @@ import (
 
 type pointsHandler struct{}
 
-func (r *pointsHandler) bindQuery(c *gin.Context, args *models.PointsArgs) (err error) {
+func (r *pointsHandler) bindPointsQuery(c *gin.Context, args *models.PointsArgs) (err error) {
 
 	// Fill in MaxResult, Page, OrderBy first to avoid custom parsing result overwritten
 	if err = c.ShouldBindQuery(args); err != nil {
@@ -63,7 +63,7 @@ func (r *pointsHandler) Get(c *gin.Context) {
 		"page":       1,
 		"sort":       "-created_at",
 	})
-	if err := r.bindQuery(c, args); err != nil {
+	if err := r.bindPointsQuery(c, args); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return
 	}


### PR DESCRIPTION
1. Revised API for /members/nickname
-  Allowed customized field selection with fields=["mail","role"]
`/members/nickname` could be used in the same way, but included one new parameter `fields`!
`fields` allow you to assign fields you want to return. Its default value was set to `id` and `nickname`.
The values should be string, closed with double quote like `"email"`. Duplicate fields(id, nickname) would be ignored if you pass these two fields. Invalid fields, like `line` would result in `400 {"Error": "Invalid fields: line"}.

@chiangkeith This fixes #168.

In your scenario, you should use
```bash
GET /members/nickname?keyword=[YOUR KEYWORD]&fields=["mail","role"]
```

2. Introduced GetMembersKeywordsArgs for better query parameters parsing

3. Add new parameter `pay_type` to assign result to be specific type
- `pay_type` has two probable values: `consumption` and `topup`
`consumption` means result is the points user spent on projects
`topup` means result is the points user pay money for

@chiangkeith This could resolves #171 