### PR TITLE
Integrated Stripe API for payment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,8 @@ type appConfig struct {
 		FollowingType         map[string]int `mapstructure:"following_type"`
 		Emotions              map[string]int `mapstructure:"emotions"`
 	} `mapstructure:"models"`
+
+	StripeKey string `mapstructure:"stripe_Key"`
 }
 
 func LoadConfig(configPath string, configName string) error {

--- a/routes/points.go
+++ b/routes/points.go
@@ -76,7 +76,7 @@ func (r *pointsHandler) Get(c *gin.Context) {
 }
 
 func (r *pointsHandler) Post(c *gin.Context) {
-	pts := models.Points{}
+	pts := models.PointsToken{}
 	if err := c.ShouldBindJSON(&pts); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return
@@ -86,6 +86,10 @@ func (r *pointsHandler) Post(c *gin.Context) {
 	}
 	if !pts.UpdatedAt.Valid {
 		pts.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+	if pts.Points.Points < 0 && pts.Token == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid Token"})
+		return
 	}
 	p, err := models.PointsAPI.Insert(pts)
 	if err != nil {

--- a/routes/points_test.go
+++ b/routes/points_test.go
@@ -92,7 +92,7 @@ func (a *mockPointsAPI) Get(args *models.PointsArgs) (result []models.PointsProj
 	return result, err
 }
 
-func (a *mockPointsAPI) Insert(pts models.Points) (result int, err error) {
+func (a *mockPointsAPI) Insert(pts models.PointsToken) (result int, err error) {
 
 	args := models.PointsArgs{ID: pts.MemberID}
 	if total, err := a.Get(&args); err == nil {
@@ -100,7 +100,7 @@ func (a *mockPointsAPI) Insert(pts models.Points) (result int, err error) {
 			result += int(v.Points.Points)
 		}
 		// mockPointsDS = append(a.mockPointsDS, models.PointsProject{Points: pts, Title: models.NullString{"", false}})
-		result += pts.Points
+		result += pts.Points.Points
 	}
 	return result, err
 }
@@ -177,6 +177,7 @@ func TestRoutePoints(t *testing.T) {
 	t.Run("Insert", func(t *testing.T) {
 		for _, testcase := range []genericTestcase{
 			genericTestcase{"BasicPoints", "POST", `/points`, `{"member_id":1,"object_type": 2,"object_id": 1,"points": 100}`, http.StatusOK, `{"points":1000}`},
+			genericTestcase{"InvalidToken", "POST", `/points`, `{"member_id":1,"object_type": 2,"object_id": 1,"points": -100}`, http.StatusBadRequest, `{"Error":"Invalid Token"}`},
 		} {
 			genericDoTest(testcase, t, asserter)
 		}


### PR DESCRIPTION
Simply use Stripe Go SDK to realize stripe charge. In order to do this, a new field `token` is required in request body when POST to `points` endpoint. There could be three conditions:

1. Points < 0. Supposed to buy points. But with empty `token`:
Not enough data to process payment. Return `400` and `{"Error": "Invalid Token"}` immediately.

2. Buy points with Points < 0, and non-null `token` field:
Could process with these data. Successful or not depend on the token.

3. Points > 0. Supposed to pay points to projects. `token` are ignored.

@chiangkeith 