### PR TITLE
API changes in Tags & Points

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -14,7 +14,7 @@ type Points struct {
 	PointsID   int64    `json:"id" db:"id"`
 	MemberID   int64    `json:"member_id" db:"member_id" binding:"required"`
 	ObjectType int      `json:"object_type" db:"object_type" binding:"required"`
-	ObjectID   int      `json:"object_id" db:"object_id" binding:"required"`
+	ObjectID   int      `json:"object_id" db:"object_id"`
 	Points     int      `json:"points" db:"points"`
 	Balance    int      `json:"balance" db:"balance"`
 	CreatedAt  NullTime `json:"created_at" db:"created_at"`

--- a/models/tags.go
+++ b/models/tags.go
@@ -114,7 +114,7 @@ func (t *tagApi) GetTags(args GetTagsArgs) (tags []Tag, err error) {
 
 	if args.Keyword != "" {
 		query.WriteString(` AND ta.tag_content LIKE :keyword`)
-		args.Keyword = args.Keyword + "%"
+		args.Keyword = "%" + args.Keyword + "%"
 	}
 
 	args.Page = (args.Page - 1) * uint16(args.MaxResult)

--- a/routes/points.go
+++ b/routes/points.go
@@ -91,6 +91,10 @@ func (r *pointsHandler) Post(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid Token"})
 		return
 	}
+	if pts.Points.ObjectID == 0 && (pts.Points.Points > 0 || pts.Points.ObjectType != 2) {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": "Invalid Object ID"})
+		return
+	}
 	p, err := models.PointsAPI.Insert(pts)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})


### PR DESCRIPTION
1. Allow ObjectID to be null in POST situation for Stripe payment
@chiangkeith, now readr-restful  will not return error for null `object_id` when `POST` to Points API.

2. Allow bi-direction regexp for tags search.
@tempo0829 I believe this minor change allow Tags API to search bi-directional for keyword. e.g.  Both `利亞` and `敘利` are valid keyword for tags `敘利亞內戰`