### PR TITLE
Follow / Emotion cache, Some Fixes and Changes

### DIFF
--- a/models/follows.go
+++ b/models/follows.go
@@ -150,7 +150,7 @@ func (g *GetFollowedArgs) get() (*sqlx.Rows, error) {
 func (g *GetFollowedArgs) scan(rows *sqlx.Rows) (interface{}, error) {
 
 	var (
-		followed []interface{}
+		followed []FollowedCount
 		err      error
 	)
 	for rows.Next() {
@@ -172,11 +172,7 @@ func (g *GetFollowedArgs) scan(rows *sqlx.Rows) (interface{}, error) {
 			}
 			followers = append(followers, int64(i))
 		}
-		followed = append(followed, struct {
-			ResourceID int64
-			Count      int
-			Followers  []int64
-		}{resourceID, count, followers})
+		followed = append(followed, FollowedCount{resourceID, count, followers})
 	}
 	return followed, err
 }
@@ -293,7 +289,7 @@ type Resource struct {
 	Emotion      int
 }
 
-type followedCount struct {
+type FollowedCount struct {
 	Resourceid int64
 	Count      int
 	Follower   []int64

--- a/models/follows_cache.go
+++ b/models/follows_cache.go
@@ -1,0 +1,79 @@
+package models
+
+import (
+	"fmt"
+	"log"
+
+	"encoding/json"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/readr-media/readr-restful/config"
+)
+
+type FollowCacheInterface interface {
+	Update(input GetFollowedArgs, followeds []FollowedCount)
+	Revoke(actionType string, resource string, emotion int, object int64)
+}
+
+type followCache struct {
+	redisIndexKey string
+	redisFieldKey string
+}
+
+func (f *followCache) followTypeMap(ftypeI int) (ftypeS string) {
+	for k, v := range config.Config.Models.Emotions {
+		if v == ftypeI {
+			return k
+		}
+	}
+	return "follow"
+}
+
+func (f followCache) Update(input GetFollowedArgs, followeds []FollowedCount) {
+	conn := RedisHelper.Conn()
+	defer conn.Close()
+
+	conn.Send("MULTI")
+	for _, followed := range followeds {
+
+		s, _ := json.Marshal(followed.Follower)
+		conn.Send("HSET", redis.Args{}.
+			Add(fmt.Sprintf(f.redisIndexKey, input.Emotion)).
+			Add(fmt.Sprintf(f.redisFieldKey, input.ResourceName, followed.Resourceid)).
+			Add(s)...)
+	}
+
+	_, err := conn.Do("EXEC")
+	if err != nil {
+		log.Printf("Error update cache to redis: %v", err)
+		return
+	}
+}
+
+func (f followCache) Revoke(actionType string, resource string, emotion int, object int64) {
+	var emotions []int
+	if actionType != "update" {
+		emotions = []int{emotion}
+	} else {
+		emotions = []int{
+			config.Config.Models.Emotions["like"],
+			config.Config.Models.Emotions["dislike"],
+		}
+	}
+
+	conn := RedisHelper.Conn()
+	defer conn.Close()
+	conn.Send("MULTI")
+
+	for _, emotion := range emotions {
+		conn.Send("HDEL", fmt.Sprintf(f.redisIndexKey, emotion), fmt.Sprintf(f.redisFieldKey, resource, object))
+	}
+
+	_, err := conn.Do("EXEC")
+	if err != nil {
+		log.Printf("Error revoke cache from redis: %v", err)
+		return
+	}
+}
+
+var FollowCache FollowCacheInterface = followCache{redisIndexKey: "followcache_%d", redisFieldKey: "%s_%d"}

--- a/models/follows_cache.go
+++ b/models/follows_cache.go
@@ -20,15 +20,6 @@ type followCache struct {
 	redisFieldKey string
 }
 
-func (f *followCache) followTypeMap(ftypeI int) (ftypeS string) {
-	for k, v := range config.Config.Models.Emotions {
-		if v == ftypeI {
-			return k
-		}
-	}
-	return "follow"
-}
-
 func (f followCache) Update(input GetFollowedArgs, followeds []FollowedCount) {
 	conn := RedisHelper.Conn()
 	defer conn.Close()

--- a/models/metaParser.go
+++ b/models/metaParser.go
@@ -20,6 +20,7 @@ type OGInfo struct {
 	Title       string `meta:"og:title" json:"og_title"`
 	Description string `meta:"og:description" json:"og_description"`
 	Image       string `meta:"og:image,og:image:url" json:"og_image"`
+	SiteName    string `meta:"og:site_name" json:"og_site_name"`
 }
 
 type ogParser struct{}

--- a/models/posts.go
+++ b/models/posts.go
@@ -63,7 +63,7 @@ type PostInterface interface {
 
 type TaggedPost struct {
 	Post
-	Tags []int `json:"tags" db:"tags"`
+	Tags NullIntSlice `json:"tags" db:"tags"`
 }
 
 type TaggedPostMember struct {

--- a/models/projects.go
+++ b/models/projects.go
@@ -17,8 +17,8 @@ type Project struct {
 	ID            int        `json:"id" db:"project_id"`
 	CreatedAt     NullTime   `json:"created_at" db:"created_at"`
 	UpdatedAt     NullTime   `json:"updated_at" db:"updated_at"`
-	UpdatedBy     NullString `json:"updated_by" db:"updated_by"`
-	PublishedAt   NullString `json:"published_at" db:"published_at"`
+	UpdatedBy     NullInt    `json:"updated_by" db:"updated_by"`
+	PublishedAt   NullTime   `json:"published_at" db:"published_at"`
 	PostID        int        `json:"post_id" db:"post_id"`
 	LikeAmount    NullInt    `json:"like_amount" db:"like_amount"`
 	CommentAmount NullInt    `json:"comment_amount" db:"comment_amount"`

--- a/models/types.go
+++ b/models/types.go
@@ -285,4 +285,34 @@ func (ns *NullFloat) UnmarshalJSON(text []byte) error {
 	return nil
 }
 
+type NullIntSlice struct {
+	Slice []int
+	Valid bool // Valid is true if Int is not NULL
+}
+
+func (ns NullIntSlice) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return ns.Slice, nil
+}
+
+func (ns NullIntSlice) MarshalJSON() ([]byte, error) {
+	if ns.Valid {
+		return json.Marshal(ns.Slice)
+	}
+	return json.Marshal(nil)
+}
+
+func (ns *NullIntSlice) UnmarshalJSON(text []byte) error {
+	ns.Valid = false
+	if string(text) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(text, &ns.Slice); err == nil {
+		ns.Valid = true
+	}
+	return nil
+}
+
 // ----------------------------- END OF NULLABLE TYPE DEFINITION -----------------------------

--- a/routes/comment.go
+++ b/routes/comment.go
@@ -103,9 +103,7 @@ func (r *commentsHandler) GetComments(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"_items": result})
 }
-func (r *commentsHandler) GetThread(c *gin.Context) {
-	c.Status(http.StatusOK)
-}
+
 func (r *commentsHandler) GetRC(c *gin.Context) {
 	var args = &models.GetReportedCommentArgs{}
 	args = args.Default()
@@ -122,6 +120,7 @@ func (r *commentsHandler) GetRC(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"_items": result})
 }
+
 func (r *commentsHandler) PostRC(c *gin.Context) {
 	report := models.ReportedComment{}
 	err := c.Bind(&report)
@@ -146,6 +145,7 @@ func (r *commentsHandler) PostRC(c *gin.Context) {
 
 	c.Status(http.StatusOK)
 }
+
 func (r *commentsHandler) PutRC(c *gin.Context) {
 	report := models.ReportedComment{}
 	err := c.Bind(&report)

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -165,6 +165,9 @@ func (r *followingHandler) Get(c *gin.Context) {
 		result, err = models.FollowingAPI.Get(input)
 	case *models.GetFollowedArgs:
 		result, err = models.FollowingAPI.Get(input)
+		if err == nil {
+			models.FollowCache.Update(*input, result.([]models.FollowedCount))
+		}
 	case *models.GetFollowMapArgs:
 		result, err = models.FollowingAPI.Get(input)
 	default:

--- a/routes/follow_test.go
+++ b/routes/follow_test.go
@@ -104,46 +104,42 @@ func getFollowing(params *models.GetFollowingArgs) (followings []interface{}, er
 }
 
 func getFollowed(args *models.GetFollowedArgs) (interface{}, error) {
-	type followedCount struct {
-		Resourceid int
-		Count      int
-		Follower   []int
-	}
+
 	switch {
 	case args.IDs[0] == 1001:
-		return []followedCount{}, nil
+		return []models.FollowedCount{}, nil
 	case args.ResourceName == "member":
-		return []followedCount{
-			followedCount{71, 1, []int{72}},
-			followedCount{72, 1, []int{71}},
+		return []models.FollowedCount{
+			models.FollowedCount{71, 1, []int64{72}},
+			models.FollowedCount{72, 1, []int64{71}},
 		}, nil
 	case args.ResourceName == "post":
 		switch args.ResourceType {
 		case "":
-			return []followedCount{
-				followedCount{42, 2, []int{71, 72}},
-				followedCount{84, 1, []int{71}},
+			return []models.FollowedCount{
+				models.FollowedCount{42, 2, []int64{71, 72}},
+				models.FollowedCount{84, 1, []int64{71}},
 			}, nil
 		case "review":
-			return []followedCount{
-				followedCount{42, 2, []int{71, 72}},
+			return []models.FollowedCount{
+				models.FollowedCount{42, 2, []int64{71, 72}},
 			}, nil
 		case "news":
-			return []followedCount{
-				followedCount{84, 1, []int{71}},
+			return []models.FollowedCount{
+				models.FollowedCount{84, 1, []int64{71}},
 			}, nil
 		}
 		return nil, nil
 	case args.ResourceName == "project":
 		switch len(args.IDs) {
 		case 1:
-			return []followedCount{
-				followedCount{840, 1, []int{72}},
+			return []models.FollowedCount{
+				models.FollowedCount{840, 1, []int64{72}},
 			}, nil
 		case 2:
-			return []followedCount{
-				followedCount{420, 2, []int{71, 72}},
-				followedCount{840, 1, []int{72}},
+			return []models.FollowedCount{
+				models.FollowedCount{420, 2, []int64{71, 72}},
+				models.FollowedCount{840, 1, []int64{72}},
 			}, nil
 		}
 		return nil, nil
@@ -190,6 +186,11 @@ func getFollowMap(args *models.GetFollowMapArgs) (list []models.FollowingMapItem
 		return []models.FollowingMapItem{}, errors.New("Resource Not Supported")
 	}
 }
+
+type mockFollowCache struct{}
+
+func (m mockFollowCache) Update(i models.GetFollowedArgs, f []models.FollowedCount)            {}
+func (m mockFollowCache) Revoke(actionType string, resource string, emotion int, object int64) {}
 
 // func initFollowTest() {
 // 	mockPostDSBack = mockPostDS

--- a/routes/mail_test.go
+++ b/routes/mail_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/gomail.v2"
 )
 
-func initMailDialer() gomail.Dialer {
+func InitMailDialer() gomail.Dialer {
 	// dialer := gomail.NewDialer(
 	// 	viper.Get("mail.host").(string),
 	// 	int(viper.Get("mail.port").(float64)),

--- a/routes/post.go
+++ b/routes/post.go
@@ -164,8 +164,9 @@ func (r *postHandler) Post(c *gin.Context) {
 			return
 		}
 	}
-	if len(post.Tags) > 0 {
-		err = models.TagAPI.UpdatePostTags(post_id, post.Tags)
+
+	if post.Tags.Valid {
+		err = models.TagAPI.UpdatePostTags(post_id, post.Tags.Slice)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return
@@ -218,8 +219,8 @@ func (r *postHandler) Put(c *gin.Context) {
 		}
 	}
 
-	if len(post.Tags) > 0 {
-		err = models.TagAPI.UpdatePostTags(int(post.ID), post.Tags)
+	if post.Tags.Valid {
+		err = models.TagAPI.UpdatePostTags(int(post.ID), post.Tags.Slice)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return

--- a/routes/post_test.go
+++ b/routes/post_test.go
@@ -326,7 +326,7 @@ func TestRoutePost(t *testing.T) {
 				genericTestcase{"NotExisted", "PUT", `/post`, `{"id":12345, "author":1}`, http.StatusBadRequest, `{"Error":"Post Not Found"}`},
 				genericTestcase{"UpdateTags", "PUT", `/post`, `{"id":1, "tags":[5,3], "updated_by":1}`, http.StatusOK, ``},
 				// UpdateSchedule the same with UpdateTags, need to be changed or confirmed
-				genericTestcase{"UpdateSchedule", "PUT", `/post`, `{"id":1, "tags":[5,3], "updated_by":1}`, http.StatusOK, ``},
+				genericTestcase{"DeleteTags", "PUT", `/post`, `{"id":1, "tags":[], "updated_by":1}`, http.StatusOK, ``},
 			},
 		},
 		TestStep{

--- a/routes/pubsub.go
+++ b/routes/pubsub.go
@@ -128,6 +128,9 @@ func (r *pubsubHandler) Push(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"Error": err.Error()})
 			return
 		}
+
+		models.FollowCache.Revoke(actionType, params.Resource, params.Emotion, params.Object)
+
 		c.Status(http.StatusOK)
 
 	case "comment":

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -116,6 +116,9 @@ func TestMain(m *testing.M) {
 	models.ReportAPI = new(mockReportAPI)
 	models.PointsAPI = new(mockPointsAPI)
 
+	models.FollowCache = new(mockFollowCache)
+	//models.CommentCache = new(mockCommentCache)
+
 	os.Exit(m.Run())
 }
 

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -75,7 +75,7 @@ func TestMain(m *testing.M) {
 	AuthHandler.SetRoutes(r)
 	CommentsHandler.SetRoutes(r)
 	FollowingHandler.SetRoutes(r)
-	MailHandler.SetRoutes(r, initMailDialer())
+	MailHandler.SetRoutes(r, InitMailDialer())
 	MemberHandler.SetRoutes(r)
 	MemoHandler.SetRoutes(r)
 	MiscHandler.SetRoutes(r)

--- a/routes/tag.go
+++ b/routes/tag.go
@@ -26,6 +26,9 @@ func (r *tagHandler) Get(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": "Bad Sorting Option"})
 		return
 	}
+	if args.Sorting == "text" {
+		args.Sorting = "tag_content"
+	}
 
 	result, err := models.TagAPI.GetTags(args)
 	if err != nil {


### PR DESCRIPTION
Functions:
1. Follow / Emotion cache, the cache now stores in Redis with the hash structure.
- Hash key format: "followcache_{emotion_type}"
  - "followcache_0" is following, "followcache_1" is like emotion ...
- Field key format: "{ResourceName}_{ResourceID}"
  - "post_1", "project_5566" ...
- The content in each field is a json-stringified _array_

Bug fixes:
1. Add go:site_map entry to Meta Info struct, this fix #180 .
2. Adjust variable types in models.Project struct, this fix #183 .
3. Resolve #186 with a new Nullable Int Slice type.
4. Map sort field "text" to "tag_content" in tag API, this might fix #185 .

Other little changes:
1. Export mail dialer initiator module for tests.
2. Remove some not-used code from comment.go.