### PR TITLE
Allow to use tagging_type to filter tagging

### DIFF
--- a/routes/tag.go
+++ b/routes/tag.go
@@ -23,11 +23,10 @@ func (r *tagHandler) Get(c *gin.Context) {
 		return
 	}
 
-	if !validateSorting(args.Sorting) {
-		c.JSON(http.StatusBadRequest, gin.H{"Error": "Bad Sorting Option"})
+	if err = args.ValidateGet(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return
 	}
-
 	if matched, err := regexp.MatchString("-?text", args.Sorting); err == nil && matched {
 		args.Sorting = strings.Replace(args.Sorting, "text", "tag_content", 1)
 	}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/readr-media/readr-restful/config"
 )
 
@@ -27,4 +30,12 @@ func ValidateTaggingType(id int) bool {
 		}
 	}
 	return false
+}
+
+func ValidateStringArgs(target, pattern string) bool {
+	if matched, err := regexp.MatchString(pattern, target); err != nil || !matched {
+		fmt.Println(matched)
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Added a new parameter `tagging_type` to enable filter `type` in `tagging`. Simply add `tagging_type={integer for specific tagging type}` in the uri.