### PR TITLE
Modify result format of get hot tags API

### DIFF
--- a/routes/tag_test.go
+++ b/routes/tag_test.go
@@ -126,8 +126,10 @@ func (t *mockTagAPI) CountTags(args models.GetTagsArgs) (int, error) {
 	return len(result), nil
 }
 
-func (t *mockTagAPI) GetHotTags() ([]models.Tag, error) { return []models.Tag{}, nil }
-func (t *mockTagAPI) UpdateHotTags() error              { return nil }
+func (t *mockTagAPI) GetHotTags() ([]models.TagRelatedResources, error) {
+	return []models.TagRelatedResources{}, nil
+}
+func (t *mockTagAPI) UpdateHotTags() error { return nil }
 
 func TestRouteTags(t *testing.T) {
 


### PR DESCRIPTION
1. Make the result format of hot tags same as the result of calling GET /tags?tagged_resources=1&stats=1
2. Change the way tag cache stored in the Redis:
 	Now store stringified tag info for each hot tags in a hash key, all hash keys are stored in the same hash structure, so the cache user might do hgetall to fetch all the tag cache at once.