### PR TITLE
API Change: get following by user

### DIFF
--- a/routes/follow.go
+++ b/routes/follow.go
@@ -82,6 +82,12 @@ func bindFollow(c *gin.Context) (result interface{}, err error) {
 				return nil, err
 			}
 		}
+		if c.Query("target_ids") != "" {
+			err = json.Unmarshal([]byte(c.Query("target_ids")), &params.TargetIDs)
+			if err != nil {
+				return nil, err
+			}
+		}
 		params.Table, params.PrimaryKey, params.FollowType, params.Active, err = metadata(params.ResourceName)
 		if err != nil {
 			return nil, err

--- a/routes/follow_test.go
+++ b/routes/follow_test.go
@@ -293,6 +293,8 @@ func TestFollowing(t *testing.T) {
 			genericTestcase{"FollowingPostReviewOK", "GET", `/following/user?resource=post&resource_type=review&id=71`, ``, http.StatusOK, nil},
 			genericTestcase{"FollowingPostNewsOK", "GET", `/following/user?resource=post&resource_type=news&id=71`, ``, http.StatusOK, nil},
 			genericTestcase{"FollowingProjectOK", "GET", `/following/user?resource=project&id=71`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowingWithTargetIDsOK", "GET", `/following/user?resource=project&id=71&target_ids=[1,2,3]`, ``, http.StatusOK, nil},
+			genericTestcase{"FollowingWithModeIDOK", "GET", `/following/user?resource=project&id=71&mode=id`, ``, http.StatusOK, nil},
 
 			genericTestcase{"FollowedPostOK", "GET", `/following/resource?resource=post&ids=[42,84]&resource_type=news`, ``, http.StatusOK, nil},
 			genericTestcase{"FollowedPostReviewOK", "GET", `/following/resource?resource=post&ids=[42,84]&resource_type=review`, ``, http.StatusOK, nil},
@@ -303,7 +305,7 @@ func TestFollowing(t *testing.T) {
 			genericTestcase{"FollowedMissingResource", "GET", `/following/resource?ids=[420,840]`, ``, http.StatusBadRequest, `{"Error":"Unsupported Resource"}`},
 			genericTestcase{"FollowedMissingID", "GET", `/following/resource?resource=post&ids=[]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
 			genericTestcase{"FollowedPostNotExist", "GET", `/following/resource?resource=post&ids=[1000,1001]&resource_type=news`, ``, http.StatusOK, nil},
-			genericTestcase{"FollowedPostStringID", "GET", `/following/resource?resourcea=post&ids=[unintegerable]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
+			genericTestcase{"FollowedPostStringID", "GET", `/following/resource?resource=post&ids=[unintegerable]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
 			genericTestcase{"FollowedProjectStringID", "GET", `/following/resource?resource=project&ids=[unintegerable]`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`},
 			genericTestcase{"FollowedProjectInvalidEmotion", "GET", `/following/resource?resource=project&ids=[42,84]&resource_type=review&emotion=angry`, ``, http.StatusBadRequest, `{"Error":"Unsupported Emotion"}`},
 


### PR DESCRIPTION
1. Add parameter: "target_id". To get resoures followed by an user only if the id of the resource exist in the target_id list
2. Add parameter: "mode". If mode = "id", the API result will be the array of resource id.