### PR TITLE
Fix user registration issue 

### DIFF
--- a/routes/mail.go
+++ b/routes/mail.go
@@ -28,6 +28,7 @@ func (r *mailHandler) sendMail(c *gin.Context) {
 	*/
 	if err := models.MailAPI.Send(input); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
 	}
 
 	c.Status(http.StatusOK)


### PR DESCRIPTION
When user first register, api could not send confirmation mail to user in `/mail` api, because user active is still 0.

Make getMailingList capable of receiving more than 1 arguments. The second argument now would be `type`, whose value is `init` for mailing to first-register users. When `init` is pass to `getMailingList`, SQL would select users with `active = 0`