### PR TITLE
Embedded tag and comments in postcache

### DIFF
--- a/models/posts_cache.go
+++ b/models/posts_cache.go
@@ -31,19 +31,6 @@ type fullCachePost struct {
 	HeadComments []CommentAuthor `json:"comments" db:"comments"`
 }
 
-func (f fullCachePost) MarshalJSON() ([]byte, error) {
-	// type FCP fullCachePost
-
-	tpm, _ := json.Marshal(f.TaggedPostMember)
-	var final map[string]interface{}
-	if err := json.Unmarshal(tpm, &final); err != nil {
-		return []byte{}, err
-	}
-	// comments, _ := json.Marshal(f.HeadComments)
-	final["comments"] = f.HeadComments
-	return json.Marshal(final)
-}
-
 func assembleCachePost(postIDs []uint32) (posts []fullCachePost, err error) {
 
 	postArgs := &PostArgs{}


### PR DESCRIPTION
Used wrapped NullString type `PostTags` as the target for MarshalJSON
`MarshalJSON` in `TaggedPostMember` is deprecated.