### PR TITLE
Implemented pnr API enable to get reports and posts by tag id

### DIFF
--- a/models/posts.go
+++ b/models/posts.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"database/sql"
 
@@ -88,6 +89,34 @@ type TaggedPostMember struct {
 	PostMember
 	Tags PostTags `json:"tags" db:"tags"`
 }
+
+// ------------ ↓↓↓ Requirement to satisfy LastPNRInterface  ↓↓↓ ------------
+
+// ReturnPublishedAt is created to return published_at and used in pnr API
+func (tpm TaggedPostMember) ReturnPublishedAt() time.Time {
+	if tpm.PublishedAt.Valid {
+		return tpm.PublishedAt.Time
+	}
+	return time.Time{}
+}
+
+// ReturnCreatedAt is created to return created_at and used in pnr API
+func (tpm TaggedPostMember) ReturnCreatedAt() time.Time {
+	if tpm.CreatedAt.Valid {
+		return tpm.CreatedAt.Time
+	}
+	return time.Time{}
+}
+
+// ReturnUpdatedAt is created to return updated_at and used in pnr API
+func (tpm TaggedPostMember) ReturnUpdatedAt() time.Time {
+	if tpm.UpdatedAt.Valid {
+		return tpm.UpdatedAt.Time
+	}
+	return time.Time{}
+}
+
+// ------------ ↑↑↑ End of requirement to satisfy LastPNRInterface  ↑↑↑ ------------
 
 type HotPost struct {
 	Post

--- a/models/posts.go
+++ b/models/posts.go
@@ -203,6 +203,8 @@ type PostArgs struct {
 	Author        map[string][]int64 `form:"author"`
 	Type          map[string][]int   `form:"type"`
 	IDs           []uint32           `form:"ids"`
+
+	Filter Filter
 }
 
 // NewPostArgs return a PostArgs struct with default settings,
@@ -258,6 +260,10 @@ func (p *PostArgs) parse() (restricts string, values []interface{}) {
 	if p.IDs != nil {
 		where = append(where, fmt.Sprintf("%s %s (?)", "posts.post_id", "IN"))
 		values = append(values, p.IDs)
+	}
+	if p.Filter != (Filter{}) {
+		where = append(where, fmt.Sprintf("posts.%s %s ?", p.Filter.Field, p.Filter.Operator))
+		values = append(values, p.Filter.Condition)
 	}
 	if len(where) > 1 {
 		restricts = strings.Join(where, " AND ")

--- a/models/posts.go
+++ b/models/posts.go
@@ -205,12 +205,22 @@ type PostArgs struct {
 	IDs           []uint32           `form:"ids"`
 }
 
+// NewPostArgs return a PostArgs struct with default settings,
+// which could be overriden at any time as long as
+// there are functions passed in whose input in *PostArgs
+func NewPostArgs(options ...func(*PostArgs)) *PostArgs {
+	args := PostArgs{MaxResult: 20, Page: 1, Sorting: "-updated_at"}
+	for _, option := range options {
+		option(&args)
+	}
+	return &args
+}
+
 func (p *PostArgs) Default() (result *PostArgs) {
 	return &PostArgs{MaxResult: 20, Page: 1, Sorting: "-updated_at"}
 }
 
 func (p *PostArgs) DefaultActive() {
-	// p.Active = map[string][]int{"$nin": []int{int(PostStatus["deactive"].(float64))}}
 	p.Active = map[string][]int{"$nin": []int{config.Config.Models.Posts["deactive"]}}
 }
 

--- a/models/reports.go
+++ b/models/reports.go
@@ -66,6 +66,8 @@ type GetReportArgs struct {
 	Sorting   string `form:"sort" json:"sort"`
 
 	Fields sqlfields `form:"fields"`
+
+	Filter Filter
 }
 
 func NewGetReportArgs(options ...func(*GetReportArgs)) *GetReportArgs {
@@ -128,7 +130,10 @@ func (p *GetReportArgs) parse() (restricts string, values []interface{}) {
 		where = append(where, "(reports.title LIKE ? OR reports.id LIKE ?)")
 		values = append(values, p.Keyword, p.Keyword)
 	}
-
+	if p.Filter != (Filter{}) {
+		where = append(where, fmt.Sprintf("reports.%s %s ?", p.Filter.Field, p.Filter.Operator))
+		values = append(values, p.Filter.Condition)
+	}
 	if len(where) > 1 {
 		restricts = strings.Join(where, " AND ")
 	} else if len(where) == 1 {

--- a/models/reports.go
+++ b/models/reports.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"database/sql"
 
@@ -172,6 +173,34 @@ type ReportAuthors struct {
 	Authors []Stunt `json:"authors"`
 	Project Project `json:"project"`
 }
+
+// ------------ ↓↓↓ Requirement to satisfy LastPNRInterface  ↓↓↓ ------------
+
+// ReturnPublishedAt is created to return published_at and used in pnr API
+func (ra ReportAuthors) ReturnPublishedAt() time.Time {
+	if ra.PublishedAt.Valid {
+		return ra.PublishedAt.Time
+	}
+	return time.Time{}
+}
+
+// ReturnCreatedAt is created to return created_at and used in pnr API
+func (ra ReportAuthors) ReturnCreatedAt() time.Time {
+	if ra.CreatedAt.Valid {
+		return ra.CreatedAt.Time
+	}
+	return time.Time{}
+}
+
+// ReturnUpdatedAt is created to return updated_at and used in pnr API
+func (ra ReportAuthors) ReturnUpdatedAt() time.Time {
+	if ra.UpdatedAt.Valid {
+		return ra.UpdatedAt.Time
+	}
+	return time.Time{}
+}
+
+// ------------ ↑↑↑ End of requirement to satisfy LastPNRInterface  ↑↑↑ ------------
 
 type ReportAuthor struct {
 	Report

--- a/models/reports.go
+++ b/models/reports.go
@@ -68,6 +68,14 @@ type GetReportArgs struct {
 	Fields sqlfields `form:"fields"`
 }
 
+func NewGetReportArgs(options ...func(*GetReportArgs)) *GetReportArgs {
+	args := GetReportArgs{MaxResult: 20, Page: 1, Sorting: "-updated_at"}
+	for _, option := range options {
+		option(&args)
+	}
+	return &args
+}
+
 func (g *GetReportArgs) Default() {
 	g.MaxResult = 20
 	g.Page = 1
@@ -75,7 +83,6 @@ func (g *GetReportArgs) Default() {
 }
 
 func (g *GetReportArgs) DefaultActive() {
-	// g.Active = map[string][]int{"$nin": []int{int(ReportActive["deactive"].(float64))}}
 	g.Active = map[string][]int{"$nin": []int{config.Config.Models.Reports["deactive"]}}
 }
 
@@ -298,7 +305,6 @@ func (a *reportAPI) InsertReport(p Report) (lastID int, err error) {
 	lastID = int(lastid)
 
 	// Only insert a report when it's active
-	// if p.Active.Valid == true && p.Active.Int == int64(ReportActive["active"].(float64)) {
 	if !p.Active.Valid || p.Active.Int != int64(config.Config.Models.Reports["deactive"]) {
 		if p.PublishStatus.Valid && p.PublishStatus.Int == int64(config.Config.Models.ReportsPublishStatus["publish"]) {
 			if p.ID == 0 {
@@ -347,7 +353,6 @@ func (a *reportAPI) UpdateReport(p Report) error {
 		return errors.New("Report Not Found")
 	}
 
-	// if p.Active.Valid == true && p.Active.Int != int64(ReportActive["active"].(float64)) {
 	if (p.PublishStatus.Valid && p.PublishStatus.Int != int64(config.Config.Models.ReportsPublishStatus["publish"])) ||
 		(p.Active.Valid && p.Active.Int != int64(config.Config.Models.Reports["active"])) {
 		// Case: Set a report to unpublished state, Delete the report from cache/searcher
@@ -477,6 +482,3 @@ func (a *reportAPI) UpdateAuthors(reportID int, authorIDs []int) (err error) {
 }
 
 var ReportAPI ReportAPIInterface = new(reportAPI)
-
-// var ReportActive map[string]interface{}
-// var ReportPublishStatus map[string]interface{}

--- a/models/tags.go
+++ b/models/tags.go
@@ -43,7 +43,7 @@ type TagInterface interface {
 	CountTags(args GetTagsArgs) (int, error)
 	GetHotTags() ([]TagRelatedResources, error)
 	UpdateHotTags() error
-	GetPostReport(args *GetPostReportArgs) ([]interface{}, error)
+	GetPostReport(args *GetPostReportArgs) ([]LastPNRInterface, error)
 }
 
 type tagApi struct{}
@@ -940,7 +940,15 @@ func (a *GetPostReportArgs) ValidateFilter() (err error) {
 	return nil
 }
 
-func (t *tagApi) GetPostReport(args *GetPostReportArgs) (results []interface{}, err error) {
+// LastPNRInterface is used in /tags/pnr
+// TaggedPostMember and ReportAuthors satisfy this interface
+type LastPNRInterface interface {
+	ReturnPublishedAt() time.Time
+	ReturnCreatedAt() time.Time
+	ReturnUpdatedAt() time.Time
+}
+
+func (t *tagApi) GetPostReport(args *GetPostReportArgs) (results []LastPNRInterface, err error) {
 
 	tagging := []struct {
 		Type     int    `db:"type"`
@@ -968,7 +976,6 @@ func (t *tagApi) GetPostReport(args *GetPostReportArgs) (results []interface{}, 
 			args.Sorting = in.Sorting
 			args.IDs = pl
 			args.Filter = in.Filter
-			// Is active setting necessary?
 			args.Active = map[string][]int{"$nin": []int{config.Config.Models.Reports["deactive"]}}
 		}
 	}
@@ -1004,7 +1011,7 @@ func (t *tagApi) GetPostReport(args *GetPostReportArgs) (results []interface{}, 
 	}
 
 	// Construct an sorted array out of two sorted array
-	results = make([]interface{}, len(posts)+len(reports))
+	results = make([]LastPNRInterface, len(posts)+len(reports))
 
 	// sorter is the function compare two arrays,
 	// which support multiple sorting

--- a/models/tags.go
+++ b/models/tags.go
@@ -927,14 +927,21 @@ func (a *GetPostReportArgs) ValidateFilter() (err error) {
 	if !utils.ValidateStringArgs(a.Filter.Field, "(created_at|updated_at|published_at)") {
 		return errors.New("Invalid Filter Field")
 	}
-	// if !utils.ValidateStringArgs(a.Filter.Operator, "(<|<=|>|>=|==)") {
+	// This will be blocked by Error: No Valid PNR Filter
+	// if !utils.ValidateStringArgs(a.Filter.Operator, "(<|<=|>|>=|==|!=)") {
 	// 	return errors.New("Invalid Filter Operator")
 	// }
 	if _, err := time.Parse(time.RFC3339, a.Filter.Condition); err != nil {
-		return errors.New("Invalid Filter Condition Time")
+		return errors.New("Invalid Filter Time Condition")
 	}
 	// If fields match a.Sorting
-	if utils.ValidateStringArgs(a.Filter.Field, a.Sorting) {
+	var sortPattern string
+	if strings.HasPrefix(a.Sorting, "-") {
+		sortPattern = strings.TrimPrefix(a.Sorting, "-")
+	} else {
+		sortPattern = a.Sorting
+	}
+	if !utils.ValidateStringArgs(a.Filter.Field, fmt.Sprintf("-?(%s)", sortPattern)) {
 		return errors.New("Inconsistent Filter Field")
 	}
 	return nil

--- a/models/tags.go
+++ b/models/tags.go
@@ -963,6 +963,9 @@ func (t *tagApi) GetPostReport(args *GetPostReportArgs) (results []LastPNRInterf
 		TargetID uint32 `db:"target_id"`
 	}{}
 	err = DB.Select(&tagging, `SELECT type, tag_id, target_id FROM tagging WHERE tag_id = ?`, args.TagID)
+	if err != nil {
+		return results, err
+	}
 
 	var (
 		postsList    []uint32

--- a/models/types.go
+++ b/models/types.go
@@ -29,6 +29,12 @@ func (s *sqlfields) GetFields(template string) (result string) {
 	return strings.Join(makeFieldString("get", template, *s), ", ")
 }
 
+type Filter struct {
+	Field     string
+	Operator  string
+	Condition string
+}
+
 // ------------------------------  NULLABLE TYPE DEFINITION -----------------------------
 
 type Nullable interface {

--- a/routes/comment.go
+++ b/routes/comment.go
@@ -92,8 +92,7 @@ func (r *commentsHandler) GetComment(c *gin.Context) {
 }
 
 func (r *commentsHandler) GetComments(c *gin.Context) {
-	// var args = &models.GetCommentArgs{}
-	// args = args.Default()
+
 	args, _ := models.NewGetCommentArgs()
 	if err := r.bindCommentQuery(c, args); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})

--- a/routes/follow.go
+++ b/routes/follow.go
@@ -92,6 +92,7 @@ func bindFollow(c *gin.Context) (result interface{}, err error) {
 				return nil, err
 			}
 		}
+
 		params.Table, params.PrimaryKey, params.FollowType, params.Active, err = metadata(params.ResourceName)
 		if err != nil {
 			return nil, err

--- a/routes/misc.go
+++ b/routes/misc.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/readr-media/readr-restful/models"
@@ -14,6 +15,21 @@ type miscHandler struct{}
 type urlMetaInfo struct {
 	URL    string         `json:"url"`
 	OGInfo *models.OGInfo `json:"og_info"`
+}
+
+// parseFilter parse the comma-seperate filters like filter=pnr:published_at<2018-06-26T08:07:27Z
+func parseFilter(filter string) (results map[string][]string) {
+
+	results = make(map[string][]string)
+
+	slicedFilters := strings.Split(filter, ",")
+	for _, v := range slicedFilters {
+		matchedGroup := regexp.MustCompile(`([A-Za-z]+):([A-Za-z_]+)(<|<=|>|>=|==|!=)([A-Za-z0-9:-]+)`).FindAllStringSubmatch(v, -1)
+		if len(matchedGroup) > 0 {
+			results[matchedGroup[0][1]] = []string{matchedGroup[0][2], matchedGroup[0][3], matchedGroup[0][4]}
+		}
+	}
+	return results
 }
 
 func (r *miscHandler) GetUrlMeta(c *gin.Context) {

--- a/routes/tag.go
+++ b/routes/tag.go
@@ -232,7 +232,7 @@ func bindGetPostReportArgs(c *gin.Context, args *models.GetPostReportArgs) (err 
 			args.Filter.Operator = val[1]
 			args.Filter.Condition = val[2]
 		} else {
-			return errors.New("No valid pnr filter")
+			return errors.New("Invalid PNR Filter")
 		}
 		if err = args.ValidateFilter(); err != nil {
 			return err
@@ -272,6 +272,7 @@ func (r *tagHandler) GetPostReport(c *gin.Context) {
 		return ""
 	}
 
+	links := make(map[string]interface{})
 	var nextLink = struct {
 		Next string `json:"url,omitempty"`
 		Page int    `json:"page,omitempty"`
@@ -285,8 +286,9 @@ func (r *tagHandler) GetPostReport(c *gin.Context) {
 		}
 		nextLink.Page = args.Page + 1
 		nextLink.Next = fmt.Sprintf("/tags/pnr/%d?max_result=%d&page=%d&sort=%s&filter=pnr:%s%s%s", args.TagID, args.MaxResult, nextLink.Page, args.Sorting, nextLinkField, "<=", lastField(args.Sorting, result[len(result)-1]))
+		links["next"] = nextLink
 	}
-	c.JSON(http.StatusOK, gin.H{"_items": result, "_links": nextLink})
+	c.JSON(http.StatusOK, gin.H{"_items": result, "_links": links})
 }
 
 func (r *tagHandler) SetRoutes(router *gin.Engine) {

--- a/routes/tag.go
+++ b/routes/tag.go
@@ -219,6 +219,31 @@ func (r *tagHandler) PutHot(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
+func bindGetPostReportArgs(c *gin.Context, args *models.GetPostReportArgs) (err error) {
+	if err := c.ShouldBindQuery(args); err != nil {
+		return err
+	}
+	if c.Param("tag_id") != "" {
+		args.TagID, _ = strconv.Atoi(c.Param("tag_id"))
+	}
+	return err
+}
+
+func (r *tagHandler) GetPostReport(c *gin.Context) {
+
+	args := models.NewGetPostReportArgs()
+	if err := bindGetPostReportArgs(c, args); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	result, err := models.TagAPI.GetPostReport(args)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"_items": result})
+}
+
 func (r *tagHandler) SetRoutes(router *gin.Engine) {
 
 	tagRouter := router.Group("/tags")
@@ -231,6 +256,8 @@ func (r *tagHandler) SetRoutes(router *gin.Engine) {
 		tagRouter.GET("/count", r.Count)
 		tagRouter.GET("/hot", r.Hot)
 		tagRouter.PUT("/hot", r.PutHot)
+
+		tagRouter.GET("/pnr/:tag_id", r.GetPostReport)
 	}
 }
 

--- a/routes/tag_test.go
+++ b/routes/tag_test.go
@@ -131,6 +131,9 @@ func (t *mockTagAPI) GetHotTags() ([]models.TagRelatedResources, error) {
 }
 func (t *mockTagAPI) UpdateHotTags() error { return nil }
 
+func (t *mockTagAPI) GetPostReport(args *models.GetPostReportArgs) ([]models.LastPNRInterface, error) {
+	return []models.LastPNRInterface{}, nil
+}
 func TestRouteTags(t *testing.T) {
 
 	tags := []models.Tag{
@@ -285,6 +288,18 @@ func TestRouteTags(t *testing.T) {
 			genericTestcase{"PostSameAsActiveTag", "POST", "/tags", `{"text":"text5566", "updated_by":931}`, http.StatusBadRequest, `{"Error":"Duplicate Entry"}`},
 		} {
 			genericDoTest(testcase, t, asserter)
+		}
+	})
+	t.Run("GetPostReport", func(t *testing.T) {
+		for _, testcase := range []genericTestcase{
+			genericTestcase{"BasicOK", "GET", "/tags/pnr/1", ``, http.StatusOK, nil},
+			genericTestcase{"FilterOK", "GET", "/tags/pnr/1?max_result=5&page=2&sort=-published_at&filter=pnr:published_at<=2018-05-17T02:54:25Z", ``, http.StatusOK, nil},
+			genericTestcase{"InvalidSort", "GET", "/tags/pnr/1?sort=author", ``, http.StatusBadRequest, `{"Error":"Invalid Sort Option"}`},
+			genericTestcase{"InvalidPNRFilter", "GET", "/tags/pnr/94?filter=pnr:published_at<<2018-06-26T08:07:27Z", ``, http.StatusBadRequest, `{"Error":"Invalid PNR Filter"}`},
+			genericTestcase{"InvalidTimeFilter", "GET", "/tags/pnr/1?filter=pnr:published_at<=2018:06:26T08-07-27Z", ``, http.StatusBadRequest, `{"Error":"Invalid Filter Time Condition"}`},
+			genericTestcase{"InconsistentFilterField", "GET", "/tags/pnr/1?sort=updated_at&filter=pnr:published_at<=2018-06-26T08:07:27Z", ``, http.StatusBadRequest, `{"Error":"Inconsistent Filter Field"}`},
+		} {
+			genericDoTest(testcase, t, nil)
 		}
 	})
 	/*

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/readr-media/readr-restful/config"
@@ -34,7 +33,6 @@ func ValidateTaggingType(id int) bool {
 
 func ValidateStringArgs(target, pattern string) bool {
 	if matched, err := regexp.MatchString(pattern, target); err != nil || !matched {
-		fmt.Println(matched)
 		return false
 	}
 	return true


### PR DESCRIPTION
## API usage
GET `/tags/pnr/{tag id}?max_result=5&page=2&sort=-published_at&filter=pnr:published_at<=2018-06-26T05:57:40Z`

### Arguments manual
- Designate the specific tag by using `tag_id`.
- `max_result` could restrict how many posts and reports altogether you want in return. Default 20
- `page` is for frontend, an indicator of which page it is now. It doesn't affect the query result. It only affect the hateoas links.
- `sort` is available to specify sort order. Now support `created_at`, `published_at`, `updated_at`. Default `-published_at`
- `filter` is used to realized pagination feature. By assigning start timing I could restrict the data section MySQL retrieves.

In first page there should be no `filter`.  The request should look like this: 
GET `/tags/pnr/{tag id}?max_result=5&sort=-published_at`

In result JSON, there would be HATEOAS section providing next link to request:
```json
"_links": {
    "next": {
        "url": "/tags/pnr/94?max_result=2&page=2&sort=-published_at&filter=pnr:published_at<=2018-06-26T05:57:40Z",
        "page": 2
    }
}
```
Please use the url in the JSON to request for next page.

- If you pass the wrong page in url, e.g.: `page=2` in first request, you will get `page=3` in the next url, and `"page": 3` in the HATEOAS section. Again, it doesn't affect the query results. The content is right. Only the page information is incorrect.
- `sort` and `filter` should have identical field.(exclude the `-` sign) You will get `Inconsistent Filter Field` error if you request resource like this:
GET `/tags/pnr/94?max_result=2&page=2&sort=-updated_at&filter=pnr:published_at<=2018-06-26T05:57:40Z`

This close #229 
