### PR TITLE
switch to alpine build image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,8 +27,10 @@ pipeline:
       branch: [master, dev]
 
   builds:
-    image: golang:1.8.5-alpine
+    image: golang:1.9-alpine
     commands:
+    - apk update
+    - apk add git make
     - make build-alpine
     # - go get github.com/robfig/cron
     # - go get github.com/garyburd/redigo/redis


### PR DESCRIPTION
It seems like drone building fail is due to ambiguous golang version.... I can not be sure in which version we were using. But after test 1.9-alpine could build docker successfully.