### PR TITLE
Update projects when report/memo is published or updated

### DIFF
--- a/models/mails.go
+++ b/models/mails.go
@@ -531,40 +531,25 @@ func (m *mailApi) SendProjectUpdateMail(resource interface{}, resourceTyep strin
 		mailData.Content = p.Description.String
 		mailData.Image = p.OgImage.String
 		mailData.HasReport = true
+
+		mailData.ProjectSlug = p.Project.Slug.String
+		mailData.ProjectTitle = p.Project.Title.String
+
 	case "memo":
-		m := resource.(Memo)
-		mailData.ProjectID = int(m.Project.Int)
-		mailData.AuthorID = int(m.Author.Int)
+		m := resource.(MemoDetail)
+		mailData.ProjectID = int(m.Project.ID)
 		mailData.Slug = strconv.Itoa(m.ID)
 		mailData.Title = m.Title.String
 		mailData.Content = m.Content.String
 		mailData.HasMemo = true
+
+		mailData.AuthorID = int(m.Author.Int)
+		mailData.AuthorImage = m.Authors.ProfileImage.String
+		mailData.AuthorName = m.Authors.Nickname.String
+
+		mailData.ProjectSlug = m.Project.Slug.String
+		mailData.ProjectTitle = m.Project.Title.String
 	}
-
-	if mailData.AuthorID > 0 {
-		author, err := MemberAPI.GetMember("id", strconv.Itoa(mailData.AuthorID))
-		if err != nil {
-			log.Println("Get member %d error when SendProjectUpdateMail", mailData.AuthorID)
-			return err
-		}
-
-		mailData.AuthorImage = author.ProfileImage.String
-		mailData.AuthorName = author.Nickname.String
-	}
-
-	if mailData.ProjectID < 0 {
-		log.Println("Invalid projectID when SendProjectUpdateMail")
-		return errors.New("Invalid projectID when SendProjectUpdateMail")
-	}
-
-	project, err := ProjectAPI.GetProject(Project{ID: mailData.ProjectID})
-	if err != nil {
-		log.Println("Get project %d error when SendProjectUpdateMail", mailData.ProjectID)
-		return err
-	}
-
-	mailData.ProjectSlug = project.Slug.String
-	mailData.ProjectTitle = project.Title.String
 
 	subLink := m.GetSubLink()
 	templatesForRoles := make(map[int]string, 0)
@@ -577,7 +562,6 @@ func (m *mailApi) SendProjectUpdateMail(resource interface{}, resourceTyep strin
 		buf := new(bytes.Buffer)
 		err = t.ExecuteTemplate(buf, "project_notifyletter.html", mailData)
 		s := buf.String()
-		log.Println(s)
 		templatesForRoles[k] = s
 	}
 

--- a/models/notificationGen.go
+++ b/models/notificationGen.go
@@ -417,31 +417,26 @@ func (c *notificationGenerator) GenerateProjectNotifications(resource interface{
 		}
 
 	case "memo":
-		m := resource.(Memo)
+		m := resource.(MemoDetail)
 		eventType := "follow_project_memo"
 		tagEventType := "follow_tag_memo"
 
-		projectFollowers, err := c.getFollowers(int(m.Project.Int), config.Config.Models.FollowingType["project"])
+		projectFollowers, err := c.getFollowers(int(m.Project.ID), config.Config.Models.FollowingType["project"])
 		if err != nil {
-			log.Println("Error get project followers", m.Project.Int, err.Error())
+			log.Println("Error get project followers", m.Project.ID, err.Error())
 		}
 
-		project, err := ProjectAPI.GetProject(Project{ID: int(m.Project.Int)})
-		if err != nil {
-			log.Println("Error get project", m.Project.Int, err.Error())
-		}
-
-		_ = c.generateTagNotifications(project, tagEventType)
+		_ = c.generateTagNotifications(m.Project.Project, tagEventType)
 
 		for _, v := range projectFollowers {
 			n := NewNotification(eventType, v)
 			n.SubjectID = strconv.Itoa(m.ID)
 			n.Nickname = m.Title.String
-			n.ProfileImage = project.HeroImage.String
-			n.ObjectName = project.Title.String
+			n.ProfileImage = m.Project.HeroImage.String
+			n.ObjectName = m.Project.Title.String
 			n.ObjectType = "project"
-			n.ObjectID = strconv.Itoa(project.ID)
-			n.ObjectSlug = project.Slug.String
+			n.ObjectID = strconv.Itoa(m.Project.ID)
+			n.ObjectSlug = m.Project.Slug.String
 			ns = append(ns, n)
 		}
 

--- a/models/posts.go
+++ b/models/posts.go
@@ -619,6 +619,10 @@ func (a *postAPI) PublishPipeline(ids []uint32) error {
 	// Insert to Algolia / Redis PostCache / Redis notification
 	// Send notify mail / slack message
 
+	if len(ids) == 0 {
+		return nil
+	}
+
 	posts, err := a.GetPosts(NewPostArgs(func(arg *PostArgs) { arg.IDs = ids }))
 	if err != nil {
 		log.Println("Getting posts info fail when running publish pipeline", err)

--- a/routes/memo.go
+++ b/routes/memo.go
@@ -84,7 +84,12 @@ func (r *memoHandler) bindQuery(c *gin.Context, args *models.MemoGetArgs) (err e
 	}
 	if c.Param("id") != "" {
 		id, _ := strconv.Atoi(c.Param("id"))
-		args.MemoID = int64(id)
+		args.IDs = []int64{int64(id)}
+	}
+	if c.Param("ids") != "" {
+		if err = json.Unmarshal([]byte(c.Query("ids")), &args.IDs); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/routes/memo_test.go
+++ b/routes/memo_test.go
@@ -40,7 +40,7 @@ func (m *mockMemoAPI) GetMemo(id int) (memo models.Memo, err error) {
 }
 func (m *mockMemoAPI) GetMemos(args *models.MemoGetArgs) (memos []models.MemoDetail, err error) {
 	switch {
-	case args.MemoID == 1:
+	case len(args.IDs) == 1:
 		return []models.MemoDetail{
 			models.MemoDetail{Memo: models.Memo{ID: 1, Title: models.NullString{"MemoTestDefault1", true}, Author: models.NullInt{131, true}, Project: models.NullInt{420, true}, Active: models.NullInt{1, true}}}}, nil
 	case len(args.Author) > 0 && len(args.Project) > 0:
@@ -125,10 +125,9 @@ func (m *mockMemoAPI) UpdateMemo(memo models.Memo) (err error) {
 	return nil
 }
 func (m *mockMemoAPI) UpdateMemos(args models.MemoUpdateArgs) (err error) { return nil }
-
-func (a *mockMemoAPI) SchedulePublish() error {
-	return nil
-}
+func (m *mockMemoAPI) SchedulePublish() ([]int, error)                    { return []int{}, nil }
+func (m *mockMemoAPI) PublishHandler(ids []int) error                     { return nil }
+func (m *mockMemoAPI) UpdateHandler(ids []int, params ...int64) error     { return nil }
 
 func TestRouteMemos(t *testing.T) {
 

--- a/routes/misc.go
+++ b/routes/misc.go
@@ -55,8 +55,23 @@ func (r *miscHandler) GetUrlMeta(c *gin.Context) {
 func (r *miscHandler) PublishResources(c *gin.Context) {
 	models.PostAPI.SchedulePublish()
 	models.ProjectAPI.SchedulePublish()
-	models.MemoAPI.SchedulePublish()
-	models.ReportAPI.SchedulePublish()
+
+	memoIDs, err := models.MemoAPI.SchedulePublish()
+	if err != nil {
+		log.Println(err)
+	} else {
+		models.MemoAPI.PublishHandler(memoIDs)
+		models.MemoAPI.UpdateHandler(memoIDs)
+	}
+
+	reportIDs, err := models.ReportAPI.SchedulePublish()
+	if err != nil {
+		log.Println(err)
+	} else {
+		models.ReportAPI.PublishHandler(reportIDs)
+		models.ReportAPI.UpdateHandler(reportIDs)
+	}
+
 	c.Status(http.StatusOK)
 }
 

--- a/routes/report_test.go
+++ b/routes/report_test.go
@@ -174,11 +174,6 @@ func (a *mockReportAPI) DeleteReport(p models.Report) error {
 	}
 	return err
 }
-
-func (a *mockReportAPI) SchedulePublish() error {
-	return nil
-}
-
 func (a *mockReportAPI) InsertAuthors(reportID int, authorIDs []int) (err error) {
 	return err
 }
@@ -186,6 +181,9 @@ func (a *mockReportAPI) InsertAuthors(reportID int, authorIDs []int) (err error)
 func (a *mockReportAPI) UpdateAuthors(reportID int, authorIDs []int) (err error) {
 	return err
 }
+func (m *mockReportAPI) SchedulePublish() ([]int, error)                { return []int{}, nil }
+func (m *mockReportAPI) PublishHandler(ids []int) error                 { return nil }
+func (m *mockReportAPI) UpdateHandler(ids []int, params ...int64) error { return nil }
 
 var MockReportAPI mockReportAPI
 


### PR DESCRIPTION
Update a project's "updated_at" and "updated_by" field when memo/report belongs the the object is published or updated.
- Refactor report/memo models, create publish handler and update handler for handling publish or update events.