### PR TITLE
Project notification mails send depends on "post_push" field

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ pipeline:
     commands:
     - gcloud source repos clone default default
     - cp default/readr-restful/main.json config/main.json
-    - cp default/readr-restful/newsletter.html config/newsletter.html
+    - cp default/readr-restful/*.html config/
     when:
       event: [push]
       branch: [master, dev]

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,7 @@ type appConfig struct {
 	Models struct {
 		Members               map[string]int `mapstructure:"members"`
 		MemberDailyPush       map[string]int `mapstructure:"member_daily_push"`
+		MemberPostPush        map[string]int `mapstructure:"member_post_push"`
 		Posts                 map[string]int `mapstructure:"posts"`
 		PostType              map[string]int `mapstructure:"post_type"`
 		PostPublishStatus     map[string]int `mapstructure:"post_publish_status"`

--- a/config/main_sample.json
+++ b/config/main_sample.json
@@ -51,6 +51,10 @@
             "deactive": 9,
             "active": 9
         },
+        "member_post_push":{
+            "deactive": 9,
+            "active": 9
+        },
         "posts":{
             "deactive": 9,
             "active": 9

--- a/models/mails.go
+++ b/models/mails.go
@@ -664,7 +664,7 @@ func (m *mailApi) SendFollowProjectMail(args FollowArgs) (err error) {
 		log.Println("Error get member when SendFollowProjectMail: ", err)
 		return err
 	}
-	if !member.DailyPush.Bool {
+	if !member.PostPush.Bool {
 		return nil
 	}
 
@@ -698,13 +698,13 @@ func (m *mailApi) getProjectFollowerMailList(id int) (receiveres []mailReceiver,
 			) AS p 
 			ON f.member_id = p.member_id 
 		WHERE m.active = %d 
-			AND m.daily_push = %d 
+			AND m.post_push = %d 
 			AND f.type = %d 
 			AND f.emotion = %d 
 			AND f.target_id = %d`,
 		config.Config.Models.PointType["project_memo"], id,
 		config.Config.Models.Members["active"],
-		config.Config.Models.MemberDailyPush["active"],
+		config.Config.Models.MemberPostPush["active"],
 		config.Config.Models.FollowingType["project"], 0,
 		id)
 


### PR DESCRIPTION
1. Project notification mails (update, follow) now send depends on "post_push" field in members table
2. Copy all mail templates to config folder when building