### PR TITLE
Fix following API and mail sending issues

### DIFF
--- a/models/follows.go
+++ b/models/follows.go
@@ -150,6 +150,20 @@ func (g *GetFollowingArgs) get() (*sqlx.Rows, error) {
 }
 
 func (g *GetFollowingArgs) scan(rows *sqlx.Rows) (result interface{}, err error) {
+
+	if g.Mode == "id" {
+		var followingIDs []int
+		for rows.Next() {
+			var f FollowingItem
+			err = rows.StructScan(&f)
+			if err != nil {
+				log.Println(fmt.Sprintf("Fail Scan Following Items: %v", err.Error()))
+			}
+			followingIDs = append(followingIDs, f.TargetID)
+		}
+		return followingIDs, nil
+	}
+
 	followingResMap := make(map[int][]FollowingItem, 0)
 	followingTypes := config.Config.Models.FollowingType
 	for rows.Next() {


### PR DESCRIPTION
1. Fix the following API with mode=id feature
2. Mail issue fix:
	- generate an empty mail body if there's no content in the day
	- do not send daily digest if mail content is empty
	- delete old mail body stored in Redis at the beginning of generating daily mail, to prevent from sending old mail if mail generating takes too long or blocked.