### PR TITLE
Implemented stage environment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,18 +13,30 @@ pipeline:
       *{{build.author}}* give *{{build.branch}}* a little push.
     when:
       event: [push]
-      branch: [master, dev]
+      branch: [master, dev, stage]
 
   get_config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
     commands:
-    - gcloud source repos clone default default
-    - cp default/readr-restful/main.json config/main.json
-    - cp default/readr-restful/*.html config/
+    - gcloud source repos clone default ../default
+    - cp ../default/readr-restful/main.json ./config/main.json
+    - cp ../default/readr-restful/*.html ./config/
     when:
       event: [push]
-      branch: [master, dev]
+      branch: [dev]
+
+  get_stage_config:
+    image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
+    secrets: [google_credentials]
+    commands:
+    - gcloud source repos clone default ../default
+    - cp ../default/readr-restful/production/main.json ./config/main.json
+    - cp ../default/readr-restful/production/.kube.yml ./.kube.yml
+    - cp ../default/readr-restful/*.html ./config/
+    when:
+      event: [push]
+      branch: [stage]
 
   builds:
     image: golang:1.9-alpine
@@ -32,20 +44,18 @@ pipeline:
     - apk update
     - apk add git make
     - make build-alpine
-    # - go get github.com/robfig/cron
-    # - go get github.com/garyburd/redigo/redis
-    # - go get github.com/gin-gonic/gin
-    # - go get github.com/readr-media/readr-restful/models
-    # - go get github.com/go-sql-driver/mysql
-    # - go get github.com/jmoiron/sqlx
-    # - go get github.com/spf13/viper
-    # - go get golang.org/x/crypto/scrypt
-    # - go get gopkg.in/gomail.v2
-    # - go test -v -cover
-    # - env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o app main.go
     when:
       event: [push]
-      branch: [master, dev]
+      branch: dev
+
+  build_stage:
+    image: golang:1.9-alpine
+    commands:
+    - apk add --update git make
+    - make build-stage
+    when:
+      event: push
+      branch: stage
 
   publish:
     image: plugins/gcr
@@ -56,7 +66,7 @@ pipeline:
     secrets: [google_credentials]
     when:
       event: [push]
-      branch: [master, dev]
+      branch: [master, dev, stage]
 
   deploy_dev:
     image: nytimes/drone-gke:develop
@@ -77,6 +87,26 @@ pipeline:
       event: [push]
       branch: dev
 
+  deploy_stage:
+    image: nytimes/drone-gke:develop
+    zone: asia-east1-a
+    cluster: prod-readr
+    namespace: default
+    # For debugging
+    dry_run: false
+    verbose: true
+    secrets:
+      - source: google_credentials
+        target: token
+    vars:
+      image: gcr.io/mirrormedia-1470651750304/${DRONE_REPO_NAME}:${DRONE_COMMIT_AUTHOR}_${DRONE_BUILD_NUMBER}
+      app: readr-restful
+      tier: backend-stage
+      branch: stage
+    when:
+      event: [push]
+      branch: stage
+
   finish_slack:
     image: plugins/slack
     channel: jenkins
@@ -86,7 +116,7 @@ pipeline:
     when:
       status: [success, failure]
       event: [push]
-      branch: [master, dev]
+      branch: [master, dev, stage]
     template: >
       {{#success build.status}}
         Build<${DRONE_BUILD_LINK}|#{{build.number}}> *success* ${DRONE_REPO_NAME}:${DRONE_COMMIT_AUTHOR}_${DRONE_BUILD_NUMBER} was well served.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM golang:1.8.5-alpine
 WORKDIR /
 RUN export GIN_MODE=release
 
-RUN mkdir /config
 ADD app /app
 ADD db_schema /db_schema
 
-ADD default/readr-restful /config/
+ADD config /config
 
 VOLUME /var/log
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,5 @@ run:
 	go run $(ALLGOFILES)
 build-alpine: deps test
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o $(BINARY) main.go
+build-stage: deps
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -o $(BINARY) main.go


### PR DESCRIPTION
When commits are pushed to `stage` branch, this push will initiate the following stage building process: 
1. Get the production setting files from corresponding directory in `default` repos. 
Those file includes `main.json` and `.kube.yml`. The json files is used as the config in `stage` deployments, while the `.kube.yml` is for the deployment usage since the deployment are a little different from `dev`.

2. Download dependencies and build, like in `dev`.
3. Published to Google Cloud Registry.
4. Deploy to production. 
`stage` branch uses deploy `readr-restful-stage`. This deployment has a standalone service `readr-restful-stage`, which would match pods with different labels from production pods. Therefore the formal request will not go into deployment `readr-restful-stage`, although they are not isolated with namespace. For the future grey-scale deployment architecture, I think the total isolation should be used on `dev` instead of `stage`.

In this way, the settings could be shared through production and stage.