### PR TITLE
Introduced Poll package

### DIFF
--- a/db_schema/19_create_table_poll.down.sql
+++ b/db_schema/19_create_table_poll.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS `polls_chosen_choice`;
+DROP TABLE IF EXISTS `polls_choices`;
+DROP TABLE IF EXISTS `polls`;
+
+

--- a/db_schema/19_create_table_poll.up.sql
+++ b/db_schema/19_create_table_poll.up.sql
@@ -1,0 +1,75 @@
+CREATE TABLE IF NOT EXISTS `polls` (
+  `id`  bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `status` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `active` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `title` varchar(256) DEFAULT NULL,
+  `description` text,
+  `total_vote` int(11) DEFAULT 0,
+  `frequency` varchar(16) DEFAULT NULL,
+  `start_at` datetime DEFAULT NULL,
+  `end_at`   datetime DEFAULT NULL,
+  `max_choice` tinyint(3) unsigned NOT NULL DEFAULT 1,
+  `changeable` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `published_at` datetime,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `created_by` bigint(20) unsigned DEFAULT NULL,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `updated_by` bigint(20) unsigned DEFAULT NULL,
+
+  PRIMARY KEY (`id`),
+  INDEX (created_by),
+  INDEX (updated_by),
+
+  FOREIGN KEY (created_by)
+    REFERENCES members (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  FOREIGN KEY (updated_by)
+    REFERENCES members (id) ON UPDATE CASCADE ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `polls_choices` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `choice` varchar(256) DEFAULT NULL,
+  `total_vote` int(11) DEFAULT 0,
+  `poll_id` bigint(20) unsigned NOT NULL,
+  `active` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `group_order` tinyint(3) unsigned NOT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `created_by` bigint(20) unsigned DEFAULT NULL,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `updated_by` bigint(20) unsigned DEFAULT NULL,
+
+  PRIMARY KEY (`id`),
+  INDEX (poll_id),
+  INDEX (created_by),
+  INDEX (updated_by),
+
+  FOREIGN KEY (poll_id)
+    REFERENCES polls (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (created_by)
+    REFERENCES members (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  FOREIGN KEY (updated_by)
+    REFERENCES members (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  UNIQUE KEY unique_order (poll_id, group_order)
+
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `polls_chosen_choice` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `member_id` bigint(20) unsigned NOT NULL,
+  `poll_id` bigint(20) unsigned NOT NULL,
+  `choice_id` bigint(20) unsigned NOT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY (`id`),
+  INDEX (member_id),
+  INDEX (poll_id),
+  INDEX (choice_id),
+
+  FOREIGN KEY (member_id)
+    REFERENCES members(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (poll_id)
+    REFERENCES polls(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY (choice_id)
+    REFERENCES polls_choices(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+

--- a/poll/filter.go
+++ b/poll/filter.go
@@ -1,0 +1,63 @@
+package poll
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetPollsFilter is used to store GET filters
+type GetPollsFilter struct {
+	MaxResults      int    `form:"max_results"`
+	Page            int    `form:"page"`
+	OrderBy         string `form:"order_by"`
+	EmbeddedChoices bool   `form:"embedded_choices"`
+}
+
+func (f *GetPollsFilter) validate() bool {
+	// TODO: validator for each filters
+	return true
+}
+
+// Parse could return a function to modify SQLO object with fields in GetPollsFilter
+func (f *GetPollsFilter) Parse() func(s *SQLO) {
+	return func(s *SQLO) {
+
+		if f.EmbeddedChoices {
+			s.join = append(s.join, " LEFT JOIN polls_choices AS choice ON polls.id = choice.poll_id")
+			s.fields = append(s.fields, sqlfield{table: "choice", pattern: `%s.%s "%s.%s"`, fields: GetStructTags("full", "db", Choice{})})
+		}
+		if f.MaxResults != 0 && f.Page > 0 {
+			s.pagination = fmt.Sprintf(" LIMIT %d OFFSET %d", f.MaxResults, f.Page-1)
+		}
+		if f.OrderBy != "" {
+			s.FormatOrderBy(f.OrderBy)
+		}
+	}
+}
+
+// SetGetPollsFilter is the constructor for GetPollsFilter, exploited in router
+// Default values are  MaxResults = 20, Page = 1, OrderBy = -updated_at
+func SetGetPollsFilter(options ...func(*GetPollsFilter) (err error)) (*GetPollsFilter, error) {
+
+	args := GetPollsFilter{MaxResults: 20, Page: 1, OrderBy: "-created_at"}
+
+	for _, option := range options {
+		if err := option(&args); err != nil {
+			return nil, err
+		}
+	}
+	return &args, nil
+}
+
+// BindQuery is used in NewRouterFilter, so it has corresponding variable fingerprints.
+// Router binds all query parameters here, including all the customized parameter forms.
+func BindQuery(c *gin.Context) func(*GetPollsFilter) error {
+
+	return func(f *GetPollsFilter) (err error) {
+		if err = c.ShouldBindQuery(f); err != nil {
+			fmt.Println(err.Error())
+		}
+		return err
+	}
+}

--- a/poll/model.go
+++ b/poll/model.go
@@ -1,0 +1,467 @@
+package poll
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/readr-media/readr-restful/models"
+)
+
+// Poll is the struct mapping to table polls
+type Poll struct {
+	ID          int64             `json:"id" db:"id"`
+	Status      int64             `json:"status" db:"status"`
+	Active      int64             `json:"active" db:"active"`
+	Title       models.NullString `json:"title" db:"title"`
+	Description models.NullString `json:"description" db:"description"`
+	TotalVote   int64             `json:"total_vote" db:"total_vote"`
+	Frequency   models.NullString `json:"frequency" db:"frequency"`
+	StartAt     models.NullTime   `json:"start_at" db:"start_at"`
+	EndAt       models.NullTime   `json:"end_at" db:"end_at"`
+	MaxChoice   int64             `json:"max_choice" db:"max_choice"`
+	Changeable  int64             `json:"changeable" db:"changeable"`
+	PublishedAt models.NullInt    `json:"published_at" db:"published_at"`
+	CreatedAt   models.NullTime   `json:"created_at" db:"created_at"`
+	CreatedBy   models.NullInt    `json:"created_by" db:"created_by"`
+	UpdatedAt   models.NullTime   `json:"updated_at" db:"updated_at"`
+	UpdatedBy   models.NullInt    `json:"updated_by" db:"updated_by"`
+}
+
+// Choice is the struct mapping to table polls_choices
+// storing choice data for each poll
+type Choice struct {
+	ID         int64             `json:"id" db:"id"`
+	Choice     models.NullString `json:"choice" db:"choice"`
+	TotalVote  models.NullInt    `json:"total_vote" db:"total_vote"`
+	PollID     models.NullInt    `json:"poll_id" db:"poll_id"`
+	Active     models.NullInt    `json:"active" db:"active"`
+	GroupOrder models.NullInt    `json:"group_order" db:"group_order"`
+	CreatedAt  models.NullTime   `json:"created_at" db:"created_at"`
+	CreatedBy  models.NullInt    `json:"created_by" db:"created_by"`
+	UpdatedAt  models.NullTime   `json:"updated_at" db:"updated_at"`
+	UpdatedBy  models.NullInt    `json:"updated_by" db:"updated_by"`
+}
+
+// ChosenChoice is the mapping struct for table polls_chosen choice
+// to record the choosing history for every users
+type ChosenChoice struct {
+	ID        int64           `json:"id" db:"id"`
+	MemberID  int64           `json:"member_id" db:"member_id"`
+	PollID    int64           `json:"poll_id" db:"poll_id"`
+	ChoiceID  int64           `json:"choice_id" db:"choice_id"`
+	CreatedAt models.NullTime `json:"created_at" db:"created_at"`
+}
+
+// ChoicesEmbeddedPoll is a single complete poll struct
+// Corresponding choices are embedded in the return values
+type ChoicesEmbeddedPoll struct {
+	Poll
+	Choices []Choice `json:"choices,omitempty" db:"choices"`
+}
+
+type pollInterface interface {
+	Get(filters *GetPollsFilter) (polls []ChoicesEmbeddedPoll, err error)
+	Insert(p ChoicesEmbeddedPoll) (err error)
+	Update(poll Poll) (err error)
+}
+
+type pollData struct{}
+
+type choiceInterface interface {
+	Get(id int) (choices []Choice, err error)
+	Insert(choices []Choice) (err error)
+	Update(choices []Choice) (err error)
+}
+
+type choiceData struct{}
+
+// GetStructTags is designed to be a public function aiming at future reuse.
+// It is also designed to be a variadic function.
+// The first argument is skip fields, which denotes the field we don't want
+func GetStructTags(mode string, tagname string, input interface{}, options ...interface{}) []string {
+
+	columns := make([]string, 0)
+	value := reflect.ValueOf(input)
+
+	// Originally used to rule out id field when insert
+	var skipFields []string
+	if options != nil {
+		skipFields = options[0].([]string)
+	}
+
+FindTags:
+	for i := 0; i < value.NumField(); i++ {
+
+		field := value.Type().Field(i)
+		fieldType := field.Type
+		fieldValue := value.Field(i)
+
+		// Use Type() to get struct tags
+		tag := value.Type().Field(i).Tag.Get(tagname)
+		// Skip fields if there are denoted
+		if len(skipFields) > 0 {
+
+			for _, f := range skipFields {
+				if tag == f {
+					fmt.Printf("Found skip fields %s!\n", f)
+					continue FindTags
+				}
+			}
+		}
+
+		if mode == "full" {
+			columns = append(columns, tag)
+		} else if mode == "non-null" {
+			// Append each tag for non-null field
+			switch fieldType.Name() {
+			case "string":
+				if fieldValue.String() != "" {
+					columns = append(columns, tag)
+				}
+			case "int64", "int":
+				if fieldValue.Int() != 0 {
+					columns = append(columns, tag)
+				}
+			case "uint32":
+				if fieldValue.Uint() != 0 {
+					columns = append(columns, tag)
+				}
+			case "NullString", "NullInt", "NullTime", "NullBool":
+				if fieldValue.FieldByName("Valid").Bool() {
+					columns = append(columns, tag)
+				}
+			default:
+				fmt.Println("unrecognised format: ", value.Field(i).Type())
+			}
+		}
+	}
+	return columns
+}
+
+type sqlsv struct {
+	statement string
+	variable  interface{}
+}
+
+type sqlfield struct {
+	table   string
+	pattern string
+	fields  []string
+}
+
+func (sf sqlfield) formatter() string {
+	var results []string
+FieldLoop:
+	for _, f := range sf.fields {
+		if f == "id" {
+			results = append(results, fmt.Sprintf(`IFNULL(%s.id, 0) "%s.id"`, sf.table, sf.table))
+			continue FieldLoop
+		}
+		switch sf.pattern {
+		case `%s.%s "%s.%s"`:
+			results = append(results, fmt.Sprintf(sf.pattern, sf.table, f, sf.table, f))
+		case `%s.%s`:
+			results = append(results, fmt.Sprintf(sf.pattern, sf.table, f))
+		default:
+			fmt.Printf("could not parse:%s\n", sf.pattern)
+		}
+	}
+	return strings.Join(results, ", ")
+}
+
+// SQLO , not SOLO, stands for "SQL Object".
+// It tries to mapping SQL statement to struct
+type SQLO struct {
+
+	// table hosts the table name for select
+	table string
+
+	// fields hosts all the fields that will appear in SELECT statement
+	fields []sqlfield
+
+	// join provide table to be joined, in string form
+	join []string
+
+	// where comprises SQL statements strings in 'WHERE' section
+	where []sqlsv
+
+	// order by maps to the ORDER BY section in SQL
+	orderby string
+
+	// pagination is the limit string, in this pattern: LIMIT [max_results] OFFSET [page-1]
+	pagination string
+
+	// args comprises all the argument corresponding to placeholders in SQL statements
+	// They will be passed into sqlx functions
+	args []interface{}
+}
+
+func (s *SQLO) FormatOrderBy(orderby string) {
+
+	tmp := strings.Split(orderby, ",")
+	for i, v := range tmp {
+		if v := strings.TrimSpace(v); strings.HasPrefix(v, "-") {
+			tmp[i] = v[1:] + " DESC"
+		} else {
+			tmp[i] = v
+		}
+	}
+	s.orderby = fmt.Sprintf(" ORDER BY %s", strings.Join(tmp, ", "))
+}
+
+func (s *SQLO) GenFields() string {
+
+	var results []string
+	for _, field := range s.fields {
+		results = append(results, field.formatter())
+	}
+	return strings.Join(results, ", ")
+}
+
+func (s *SQLO) SQL() string {
+
+	base := bytes.NewBufferString(fmt.Sprintf("SELECT %s FROM %s", s.GenFields(), s.table))
+	for _, join := range s.join {
+		base.WriteString(join)
+	}
+	if len(s.where) > 0 {
+		base.WriteString(" WHERE")
+	}
+	for _, condition := range s.where {
+		base.WriteString(condition.statement)
+		s.args = append(s.args, condition.variable)
+	}
+	if s.orderby != "" {
+		base.WriteString(s.orderby)
+	}
+	if s.pagination != "" {
+		base.WriteString(s.pagination)
+	}
+	base.WriteString(";")
+	return base.String()
+}
+
+func NewSQLO(options ...func(*SQLO)) *SQLO {
+	so := SQLO{}
+	for _, option := range options {
+		option(&so)
+	}
+	return &so
+}
+
+func (p *pollData) Get(filter *GetPollsFilter) (polls []ChoicesEmbeddedPoll, err error) {
+
+	osql := NewSQLO(func(s *SQLO) {
+		s.table = "polls"
+		s.fields = append(s.fields, sqlfield{table: "polls", pattern: `%s.%s`, fields: []string{"*"}})
+	}, filter.Parse())
+	rows, err := models.DB.Queryx(osql.SQL(), osql.args...)
+	if err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+ScanLoop:
+	for rows.Next() {
+		// Corresponding struct for joined table
+		var poll struct {
+			Poll
+			Choice `db:"choice"`
+		}
+		if err = rows.StructScan(&poll); err != nil {
+			log.Fatal("Error scan polls\n", err)
+			return nil, err
+		}
+		// Append choices if there is already a poll entry for this poll id
+		for i, v := range polls {
+			if v.ID == poll.Poll.ID {
+				if poll.Choice.ID != 0 {
+					polls[i].Choices = append(polls[i].Choices, poll.Choice)
+				}
+				continue ScanLoop
+			}
+		}
+		// Poll id not existing. Create new poll for this id
+		if poll.Choice.ID != 0 {
+			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll, Choices: []Choice{poll.Choice}})
+		} else {
+			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll})
+		}
+	}
+	return polls, err
+}
+
+// Insert allows consumer to insert a poll at a time.
+// This poll could have attached choices, which will be also inserted as well.
+// Insert does not allow empty poll with choices, you have to insert poll first.
+// If it's needed to insert new choice, use choice api instead.
+func (p *pollData) Insert(poll ChoicesEmbeddedPoll) (err error) {
+
+	pollTags := GetStructTags("full", "db", Poll{})
+	tx, err := models.DB.Beginx()
+	if err != nil {
+		log.Printf("Fail to get sql connection: %v\n", err)
+		return err
+	}
+	// Either rollback or commit transaction
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+		err = tx.Commit()
+	}()
+
+	// Insert poll first
+	// Notice colon in 'VALUES (:%s)', because strings.Join will not create the first colon
+	pollQ := fmt.Sprintf(`INSERT INTO polls (%s) VALUES (:%s)`,
+		strings.Join(pollTags, ","), strings.Join(pollTags, ",:"))
+	pollInserted, err := tx.NamedExec(pollQ, poll.Poll)
+	if err != nil {
+		return err
+	}
+	pollID, err := pollInserted.LastInsertId()
+	if err != nil {
+		return err
+	}
+	if len(poll.Choices) > 0 {
+		choiceTags := GetStructTags("full", "db", Choice{})
+
+		choiceQ := fmt.Sprintf(`INSERT INTO polls_choices (%s) VALUES (:%s)`,
+			strings.Join(choiceTags, ","), strings.Join(choiceTags, ",:"))
+
+		// Change poll_id in options to the poll id we just inserted
+		// Batch insert for tx is merged but not released yet, use for loop
+		// Info: https://github.com/jmoiron/sqlx/pull/285
+		for _, choice := range poll.Choices {
+			choice.PollID.Int = pollID
+			choice.PollID.Valid = true
+			if _, err := tx.NamedExec(choiceQ, choice); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Update single row of poll
+func (p *pollData) Update(poll Poll) (err error) {
+
+	pollTags := GetStructTags("non-null", "db", poll)
+	pollFields := func(tags []string) string {
+		var temp []string
+		for _, tag := range tags {
+			temp = append(temp, fmt.Sprintf(`%s = :%s`, tag, tag))
+		}
+		return strings.Join(temp, ", ")
+	}(pollTags)
+	query := fmt.Sprintf(`Update polls SET %s WHERE id = :id`, pollFields)
+	if _, err := models.DB.NamedExec(query, poll); err != nil {
+		log.Fatal(err)
+		return err
+	}
+	return nil
+}
+
+func (c *choiceData) Get(pollID int) (results []Choice, err error) {
+
+	Q := `SELECT * FROM polls_choices WHERE poll_id = ?;`
+	rows, err := models.DB.Queryx(Q, pollID)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var choice Choice
+		if err := rows.StructScan(&choice); err != nil {
+			return nil, err
+		}
+		results = append(results, choice)
+	}
+	return results, err
+}
+
+func RepeatString(target string, times int, delimiter string) (result string) {
+	var inter []string
+	for i := 0; i < times; i++ {
+		inter = append(inter, target)
+	}
+	return strings.Join(inter, delimiter)
+}
+
+func (c *choiceData) Insert(choices []Choice) (err error) {
+
+	choiceTags := GetStructTags("full", "db", Choice{})
+
+	choiceQ := fmt.Sprintf(`INSERT INTO polls_choices (%s) VALUES (:%s)`,
+		strings.Join(choiceTags, ", "), strings.Join(choiceTags, ", :"))
+
+	tx, err := models.DB.Beginx()
+	if err != nil {
+		log.Printf("Fail to get sql connection: %v\n", err)
+		return err
+	}
+	// Either rollback or commit transaction
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+		err = tx.Commit()
+	}()
+	// Change poll_id in options to the poll id we just inserted
+	// Batch insert for tx is merged but not released yet, use for loop
+	// Info: https://github.com/jmoiron/sqlx/pull/285
+	for _, choice := range choices {
+		// Maybe it could be implemented using Prepare and exec
+		// to avoid prepare statement for each loop
+		if _, err := tx.NamedExec(choiceQ, choice); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Update single choice
+func (c *choiceData) Update(choices []Choice) (err error) {
+
+	tx, err := models.DB.Beginx()
+	if err != nil {
+		log.Printf("Fail to get sql connection: %v\n", err)
+		return err
+	}
+	// Either rollback or commit transaction
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+		err = tx.Commit()
+	}()
+	for _, choice := range choices {
+
+		choiceTags := GetStructTags("non-null", "db", choice)
+		choiceFields := func(tags []string) string {
+			var temp []string
+			for _, tag := range tags {
+				temp = append(temp, fmt.Sprintf(`%s = :%s`, tag, tag))
+			}
+			return strings.Join(temp, ", ")
+		}(choiceTags)
+		query := fmt.Sprintf(`Update polls_choices SET %s WHERE id = :id`, choiceFields)
+		if _, err = tx.NamedExec(query, choice); err != nil {
+			log.Fatal(err)
+			return err
+		}
+	}
+	return nil
+}
+
+// PollData is the pointer instance of pollData struct, which implements pollInterface
+// It provides data layer abstraction
+var PollData = new(pollData)
+
+// ChoiceData is the pointer instance of choiceData struct, which implements choiceInterface,
+// to provide choice database abstraction
+var ChoiceData = new(choiceData)

--- a/poll/router.go
+++ b/poll/router.go
@@ -1,0 +1,151 @@
+package poll
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type router struct{}
+
+// GetPolls returns list of polls. If filter provided,
+// it could return polls with corresponding choices
+func (r *router) GetPolls(c *gin.Context) {
+
+	filter, err := SetGetPollsFilter(BindQuery(c))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	results, err := PollData.Get(filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"_items": results})
+}
+
+// PostPolls accepts a single poll w/o choices
+// and create new poll using input data
+func (r *router) PostPolls(c *gin.Context) {
+
+	poll := ChoicesEmbeddedPoll{}
+	if err := c.Bind(&poll); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	// ----------- Start of input validation
+	poll.Poll.Validate(
+		ValidatePollInsertID,
+		ValidatePollCreatedAt,
+		ValidatePollUpdatedAt,
+	)
+	// Validate attached choices
+	for i := range poll.Choices {
+		poll.Choices[i].Validate(
+			ValidateChoiceInsertID,
+			ValidateChoiceCreatedAt,
+			ValidateChoiceUpdatedAt,
+		)
+	} // --------- End of input validation
+	if err := PollData.Insert(poll); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.Status(http.StatusCreated)
+}
+
+// PutPolls updates contents of a single poll
+func (r *router) PutPolls(c *gin.Context) {
+
+	poll := Poll{}
+	if err := c.Bind(&poll); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	// validation sections
+	poll.Validate(ValidatePollUpdatedAt)
+	err := PollData.Update(poll)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (r *router) GetChoices(c *gin.Context) {
+
+	pollID, _ := strconv.ParseInt(c.Param("id"), 10, 64)
+	results, err := ChoiceData.Get(int(pollID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"_items": results})
+}
+
+func (r *router) InsertChoices(c *gin.Context) {
+
+	pollID, _ := strconv.ParseInt(c.Param("id"), 10, 64)
+	var input struct {
+		Choices []Choice `json:"choices"`
+	}
+	if err := c.Bind(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	// ------------ Start of input validation
+	for i := range input.Choices {
+		input.Choices[i].Validate(
+			ValidateChoiceInsertID,
+			ValidateChoiceCreatedAt,
+			ValidateChoiceUpdatedAt,
+			ValidateChoicePollID(pollID))
+	} // ---------- End of input validation
+	if err := ChoiceData.Insert(input.Choices); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.Status(http.StatusCreated)
+}
+
+func (r *router) PutChoices(c *gin.Context) {
+
+	pollID, _ := strconv.ParseInt(c.Param("id"), 10, 64)
+	var input struct {
+		Choices []Choice `json:"choices"`
+	}
+	if err := c.Bind(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	for i := range input.Choices {
+		input.Choices[i].Validate(
+			ValidateChoicePollID(pollID),
+			ValidateChoiceUpdatedAt,
+		)
+	}
+	if err := ChoiceData.Update(input.Choices); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (r *router) SetRoutes(router *gin.Engine) {
+
+	v2 := router.Group("/v2/polls")
+	{
+		v2.GET("", r.GetPolls)
+		v2.POST("", r.PostPolls)
+		v2.PUT("", r.PutPolls)
+
+		v2.GET("/:id/choices", r.GetChoices)
+		v2.POST("/:id/choices", r.InsertChoices)
+		v2.PUT("/:id/choices", r.PutChoices)
+	}
+}
+
+// Router is the single routing instance used in registration in routes/routes.go
+var Router router

--- a/poll/validator.go
+++ b/poll/validator.go
@@ -1,0 +1,79 @@
+package poll
+
+import (
+	"time"
+
+	"github.com/readr-media/readr-restful/models"
+)
+
+// Validate exploit functions to check and modify the content of Poll
+func (p *Poll) Validate(modifiers ...func(*Poll)) {
+
+	for _, modifier := range modifiers {
+		modifier(p)
+	}
+}
+
+// ValidatePollInsertID remove the id field if necessary
+func ValidatePollInsertID(p *Poll) {
+	if p.ID != 0 {
+		p.ID = 0
+	}
+}
+
+// ValidatePollCreatedAt set created_at of Poll to current time
+func ValidatePollCreatedAt(p *Poll) {
+	if !p.CreatedAt.Valid {
+		p.CreatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+}
+
+// ValidatePollUpdatedAt set updated_at of Poll to now
+func ValidatePollUpdatedAt(p *Poll) {
+	if p.UpdatedAt.Valid {
+		p.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+}
+
+// ValidateChoiceInsertID remove the id field if necessary
+func ValidateChoiceInsertID(c *Choice) {
+	// If assign insert will cause repeat primary key error in MySQL
+	// Set it to 0 to enable auto_increment
+	if c.ID != 0 {
+		c.ID = 0
+	}
+}
+
+// ValidateChoiceCreatedAt set created_at of Choice to current time
+func ValidateChoiceCreatedAt(c *Choice) {
+
+	if !c.CreatedAt.Valid {
+		c.CreatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+}
+
+// ValidateChoiceUpdatedAt set updated_at of Choice to now
+func ValidateChoiceUpdatedAt(c *Choice) {
+	if !c.UpdatedAt.Valid {
+		c.UpdatedAt = models.NullTime{Time: time.Now(), Valid: true}
+	}
+}
+
+// ValidateChoicePollID check the poll_id field, and set it to pollID
+// if PollID is not valid, or PollID is valid but not equal to pollID
+func ValidateChoicePollID(pollID int64) func(c *Choice) {
+	return func(c *Choice) {
+		if !c.PollID.Valid || (c.PollID.Valid && c.PollID.Int != pollID) {
+			c.PollID.Int = pollID
+			c.PollID.Valid = true
+		}
+	}
+}
+
+// Validate takes a series modifiers to check a single Choice
+func (c *Choice) Validate(modifiers ...func(*Choice)) {
+
+	for _, modifier := range modifiers {
+		modifier(c)
+	}
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,8 +1,10 @@
 package routes
 
-import "github.com/gin-gonic/gin"
-
-import "github.com/readr-media/readr-restful/pkg/mail"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/readr-media/readr-restful/pkg/mail"
+	"github.com/readr-media/readr-restful/poll"
+)
 
 type RouterHandler interface {
 	SetRoutes(router *gin.Engine)
@@ -26,6 +28,7 @@ func SetRoutes(router *gin.Engine) {
 		&PubsubHandler,
 		&ReportHandler,
 		&TagHandler,
+		&poll.Router,
 	} {
 		h.SetRoutes(router)
 	}


### PR DESCRIPTION
This PR provide basic create, retrieve, and update functionality for poll and choice correspondingly. Based on its architecture modification and futuristic API principle changes, its URL will be denoted as `/v2/polls` for distinguishment.

APIs' designs referenced [Zalando's guideline](https://opensource.zalando.com/restful-api-guidelines/) greatly.

## Changelog
### Polls
#### GET
route: `/v2/polls/`
filters: `max_results`, `page`, `sort`, `embed`
status code: `200`

Listing API for polls provides 4 parameter for filtering now. `max_results`, `page`, `sort` are for pagination as usual. `sort` comprises of comma-separated database fields that indicates how to sort the results of polls.

`embed` controls whether to show corresponding choices with poll. It accepts also comma-separated string, like `embed=choices,selection`. But now we only support `choices`. Once denoting `choices` in `embed` filter, this API will return choices together with poll then.

#### POST
route: `/v2/polls/`
validate fields: `created_at`, `updated_at`
status code: `201`

Send corresponding Poll data to insert data. This API will check `created_at` and `updated_at` and make them current time if not presented. 

What's special is, in this API it accepts a choices array as `choices`. `choices` is totally optional. 
 If it's presented, this poll will be inserted together with these choices in identical request as well. If not, then only single poll will be stored.

The request body will be like this:
```json
{
	"status": 2,
	"title": "台灣有政治釋迦嗎？",
	"frequency": "* * * * * *",
	"type": 1,
	"changeable": 2,
	"created_by": 648,
	"status": 0,
	"active": 0,
	"choices":[
	{
            "choice": "有",
            "total_vote": 0,
            "poll_id": 2,
            "created_at": null,
            "created_by": 648,
            "status":0,
            "active": 0,
            "group_order": 1
	}]
}
```
#### PUT
route: `/v2/polls`
validate fields: `updated_at`
status code: `204`

This API will only update a poll with its payload at a time. It doesn't accept `choices` like in POST. If you want to update choice, use relative API for choices.

###  Choice
#### GET
router: `/v2/polls/:id/choices`
status code: `200`

This API return choices for specific poll by using `id` parameter. There are no special check items or filter right now.

#### POST
router: `/v2/polls/:id/choices`
validate field: `poll_id`, `created_at`, `updated_at`
status code: `201`

This API could insert **multiple** choices at a time. So it accepts choices as an array, `choices`. Its format for payload is like:
```json
{
	"choices": [
        {
            "choice": "遙遙",
            "total_vote": 0,
            "poll_id": 1,
            "created_by": 648,
            "active": 0,
            "status": 0,
            "group_order": 2
	}
    ]
}
```
It will validate the field `poll_id` with the `id` term in url parameters. If they are mismatched, API will adjust `poll_id` to `id` automatically.

#### PUT
router: `/v2/polls/:id/choices`
validate fields: `updated_at`
status code: `204`

This API update **multiple** choices at a time. It accepts an array like in POST as well.