### PR TITLE
Poll API filter enhancements

### DIFF
--- a/db_schema/20_chosen_choice_add_active.down.sql
+++ b/db_schema/20_chosen_choice_add_active.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE polls MODIFY `frequency` varchar(16) DEFAULT NULL;
+ALTER TABLE polls_chosen_choice DROP COLUMN `active`;
+ALTER TABLE polls_chosen_choice MODIFY `created_at` datetime DEFAULT NOW();

--- a/db_schema/20_chosen_choice_add_active.up.sql
+++ b/db_schema/20_chosen_choice_add_active.up.sql
@@ -1,0 +1,4 @@
+UPDATE polls SET frequency = '0';
+ALTER TABLE polls MODIFY `frequency` tinyint(3) NOT NULL DEFAULT 0;
+ALTER TABLE polls_chosen_choice ADD COLUMN `active` tinyint(3) NOT NULL DEFAULT 0 AFTER `choice_id`;
+ALTER TABLE polls_chosen_choice MODIFY `created_at` datetime NOT NULL DEFAULT NOW();

--- a/poll/filter.go
+++ b/poll/filter.go
@@ -1,28 +1,108 @@
 package poll
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-// GetPollsFilter is used to store GET filters
-type GetPollsFilter struct {
-	MaxResults int    `form:"max_results"`
-	Page       int    `form:"page"`
-	Sort       string `form:"sort"`
-	Embed      string `form:"embed"`
+func OperatorParser(operator string) (result string) {
+	switch operator {
+	case "gte":
+		result = `>=`
+	case "gt":
+		result = `>`
+	case "lte":
+		result = `<=`
+	case "lt":
+		result = `<`
+	case "neq":
+		result = `!=`
+	case "eq":
+		result = `=`
+	case "in":
+		result = `IN`
+	case "nin":
+		result = `NOT IN`
+	default:
+		result = ``
+	}
+	return result
 }
 
-func (f *GetPollsFilter) validate() bool {
+func ParamsParser(rhs string, mode string) (operators []string, values []interface{}, err error) {
+
+	var pattern string
+	switch mode {
+	case "comma-separated":
+		pattern = `\s*(?P<operator>gte|gt|lte|lt|eq|neq|in|nin)\s*:\s*(?P<data>[[0-9-,]+])`
+	case "datetime":
+		pattern = `\s*(?P<operator>gte|gt|lte|lt|eq|neq|in|nin)\s*:\s*(?P<data>[0-9-:TZ]+)`
+	}
+	re := regexp.MustCompile(pattern)
+	cutted := re.FindAllStringSubmatch(rhs, -1)
+	for _, filter := range cutted {
+		operators = append(operators, filter[1])
+		switch mode {
+		case "comma-separated":
+			var csv []int
+			if err := json.Unmarshal([]byte(filter[2]), &csv); err != nil {
+				return nil, nil, err
+			}
+			values = append(values, csv)
+		case "datetime":
+			t, err := time.Parse(time.RFC3339, filter[2])
+			if err != nil {
+				return nil, nil, err
+			}
+			values = append(values, t)
+		}
+	}
+	return operators, values, nil
+}
+
+// ListPollsFilter is used to store GET filters
+type ListPollsFilter struct {
+	MaxResult int    `form:"max_result"`
+	Page      int    `form:"page"`
+	Sort      string `form:"sort"`
+	Embed     string `form:"embed"`
+
+	Status  string `form:"status"`
+	Active  int64  `form:"active"`
+	StartAt string `form:"start_at"`
+	IDS     string `form:"ids"`
+}
+
+func (f *ListPollsFilter) validate() bool {
 	// TODO: validator for each filters
 	return true
 }
 
-// Parse could return a function to modify SQLO object with fields in GetPollsFilter
-func (f *GetPollsFilter) Parse() func(s *SQLO) {
+// Parse could return a function to modify SQLO object with fields in ListPollsFilter
+func (f *ListPollsFilter) Parse() func(s *SQLO) {
 	return func(s *SQLO) {
+		if f.IDS != "" {
+			operator, value, err := ParamsParser(f.IDS, "comma-separated")
+			if err != nil {
+				log.Println(err.Error())
+				return
+			}
+			i := 0
+			for i < len(operator) {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("polls.id %s (?)", OperatorParser(operator[i])), variable: value[i]})
+				i++
+			}
+		}
+		// active should be labeled with "polls.active", since all three tables have the column "active"
+		// It could be ambiguous for MySQL for placing simple active here
+		s.where = append(s.where, sqlsv{statement: "polls.active = ?", variable: f.Active})
 		if f.Embed != "" {
 			embedded := strings.Split(f.Embed, ",")
 
@@ -34,20 +114,45 @@ func (f *GetPollsFilter) Parse() func(s *SQLO) {
 				}
 			}
 		}
-		if f.MaxResults != 0 && f.Page > 0 {
-			s.pagination = fmt.Sprintf(" LIMIT %d OFFSET %d", f.MaxResults, f.Page-1)
+		if f.MaxResult != 0 && f.Page > 0 {
+			s.pagination = fmt.Sprintf(" LIMIT %d OFFSET %d", f.MaxResult, f.Page-1)
 		}
 		if f.Sort != "" {
 			s.FormatOrderBy(f.Sort)
 		}
+		// f.Status=in:[0,1],nin:[3]
+		if f.Status != "" {
+			condition, value, err := ParamsParser(f.Status, "comma-separated")
+			if err != nil {
+				log.Printf(err.Error())
+				return
+			}
+			i := 0
+			for i < len(condition) {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("status %s (?)", OperatorParser(condition[i])), variable: value[i]})
+				i++
+			}
+		}
+		if f.StartAt != "" {
+			condition, value, err := ParamsParser(f.StartAt, "datetime")
+			if err != nil {
+				log.Printf(err.Error())
+				return
+			}
+			i := 0
+			for i < len(condition) {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("start_at %s ?", OperatorParser(condition[i])), variable: value[i]})
+				i++
+			}
+		}
 	}
 }
 
-// SetGetPollsFilter is the constructor for GetPollsFilter, exploited in router
-// Default values are  MaxResults = 20, Page = 1, OrderBy = -updated_at
-func SetGetPollsFilter(options ...func(*GetPollsFilter) (err error)) (*GetPollsFilter, error) {
+// SetListPollsFilter is the constructor for ListPollsFilter, exploited in router
+// Default values are MaxResult = 20, Page = 1, OrderBy = -updated_at
+func SetListPollsFilter(options ...func(*ListPollsFilter) (err error)) (*ListPollsFilter, error) {
 
-	args := GetPollsFilter{MaxResults: 20, Page: 1, Sort: "-created_at"}
+	args := ListPollsFilter{MaxResult: 20, Page: 1, Sort: "-created_at", Active: 1}
 
 	for _, option := range options {
 		if err := option(&args); err != nil {
@@ -59,11 +164,62 @@ func SetGetPollsFilter(options ...func(*GetPollsFilter) (err error)) (*GetPollsF
 
 // BindQuery is used in NewRouterFilter, so it has corresponding variable fingerprints.
 // Router binds all query parameters here, including all the customized parameter forms.
-func BindQuery(c *gin.Context) func(*GetPollsFilter) error {
-	return func(f *GetPollsFilter) (err error) {
+func BindListPollsFilter(c *gin.Context) func(*ListPollsFilter) error {
+	return func(f *ListPollsFilter) (err error) {
 		if err = c.ShouldBindQuery(f); err != nil {
 			fmt.Println(err.Error())
 		}
 		return err
+	}
+}
+
+type ListPicksFilter struct {
+	PollID    int64
+	Member    int64  `form:"member"`
+	Active    int64  `form:"active"`
+	CreatedAt string `form:"created_at"`
+}
+
+func SetListPicksFilter(options ...func(*ListPicksFilter) (err error)) (*ListPicksFilter, error) {
+	args := ListPicksFilter{}
+	for _, option := range options {
+		if err := option(&args); err != nil {
+			return nil, err
+		}
+	}
+	return &args, nil
+}
+
+func BindListPicksFilter(c *gin.Context) func(*ListPicksFilter) error {
+	return func(f *ListPicksFilter) (err error) {
+		if err = c.ShouldBindQuery(f); err != nil {
+			fmt.Println(err.Error())
+		}
+		if c.Param("id") != "" {
+			f.PollID, _ = strconv.ParseInt(c.Param("id"), 10, 64)
+		}
+		return err
+	}
+}
+
+func (f *ListPicksFilter) Parse() func(s *SQLO) {
+	return func(s *SQLO) {
+		s.where = append(s.where, sqlsv{statement: "active = ?", variable: f.Active})
+
+		if f.PollID != 0 {
+			s.where = append(s.where, sqlsv{statement: "poll_id = ?", variable: f.PollID})
+		}
+
+		if f.Member != 0 {
+			s.where = append(s.where, sqlsv{statement: "member_id = ?", variable: f.Member})
+		}
+		// Parse format like: created_at=gte:2018-11-22, lt:2018-11-24
+		if f.CreatedAt != "" {
+			cutter := regexp.MustCompile(`\s*(?P<operator>gte|gt|lte|lt|eq|neq)\s*:(?P<data>[0-9-]+)`)
+			cutted := cutter.FindAllStringSubmatch(f.CreatedAt, -1)
+			for _, filter := range cutted {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("created_at %s ?", OperatorParser(filter[1])), variable: filter[2]})
+			}
+		}
 	}
 }

--- a/poll/router.go
+++ b/poll/router.go
@@ -13,7 +13,7 @@ type router struct{}
 // it could return polls with corresponding choices
 func (r *router) GetPolls(c *gin.Context) {
 
-	filter, err := SetGetPollsFilter(BindQuery(c))
+	filter, err := SetListPollsFilter(BindListPollsFilter(c))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return
@@ -133,6 +133,28 @@ func (r *router) PutChoices(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+func (r *router) GetPicks(c *gin.Context) {
+	filter, err := SetListPicksFilter(BindListPicksFilter(c))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		return
+	}
+	picks, err := PickData.Get(filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"_items": picks})
+}
+
+func (r *router) InsertPicks(c *gin.Context) {
+	c.Status(http.StatusCreated)
+}
+
+func (r *router) UpdatePicks(c *gin.Context) {
+	c.Status(http.StatusNoContent)
+}
+
 func (r *router) SetRoutes(router *gin.Engine) {
 
 	v2 := router.Group("/v2/polls")
@@ -144,6 +166,10 @@ func (r *router) SetRoutes(router *gin.Engine) {
 		v2.GET("/:id/choices", r.GetChoices)
 		v2.POST("/:id/choices", r.InsertChoices)
 		v2.PUT("/:id/choices", r.PutChoices)
+
+		v2.GET("/:id/picks", r.GetPicks)
+		v2.POST("/:id/picks", r.InsertPicks)
+		v2.PUT("/:id/picks", r.UpdatePicks)
 	}
 }
 


### PR DESCRIPTION
In this PR I adjusted the table schema to fit specs, and provided new filter items for polls. There are some formal implementation for RHS colon filter format.

## Changelog
### Database migration
`polls/frequency`: varchar -> tinyint
`polls_chosen_choice/active`: new column `active`
`polls_chosen_choice/created_at`: NULL -> NOT NULL

### Provide filter for `start_at`, `status`, `active`, and `ids`
Examples:
`ids=in:[1,2,3,9],nin:[7,6]`
`start_at=gte:2018-11-24T15:04:05Z,lt:2018-11-28T15:04:05Z`
`active=1`
`status=in:[0,1]`

### RHS colon filter
This is the new version of filter, that have the general format: `<field>=<operator>:<value>`. `<operator>:<value>` could have multiple sets for one `<field>` if you use comma(,) to separate different sets. It has two kinds: *comma-separate integer* and *datetime*. 

#### Comma-separated integer filter
**format:**`<field>=<operaor>:[value1, value2, ..., ...]`
**support field:**`status`, `ids`
**example:**`ids=in:[1,2,3,9],nin:[7,6]`
This kind of filter takes an array of integers for the `<value>` part. It's used for scenario that you want the result rows have specific field within certain range. Take the example above, this filter will list polls with id 1,2,3,9 and not in 6,7. `status` could use this filter as well.

#### Datetime filter
**format:**`<field>=<operaor>:<datetime>, <operator>:<datetime>`
**support field:**`start_at`
**example:**`start_at=gte:2018-11-24T15:04:05Z,lt:2018-11-28T15:04:05Z`
This kind of filter takes only datetime string that could select polls based on time. For the example above, this filter will list polls whose `start_at` are between `2018-11-24T15:04:05` and `2018-11-28T15:04:05`