### PR TITLE
Provided embed option for created_by

### DIFF
--- a/poll/filter.go
+++ b/poll/filter.go
@@ -2,10 +2,10 @@ package poll
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -189,8 +189,8 @@ func BindListPollsFilter(c *gin.Context) func(*ListPollsFilter) error {
 }
 
 type ListPicksFilter struct {
-	PollID    int64
-	Member    int64  `form:"member"`
+	PollID    string `form:"poll_id"`
+	MemberID  int64  `form:"member_id"`
 	Active    int64  `form:"active"`
 	CreatedAt string `form:"created_at"`
 }
@@ -210,8 +210,8 @@ func BindListPicksFilter(c *gin.Context) func(*ListPicksFilter) error {
 		if err = c.ShouldBindQuery(f); err != nil {
 			fmt.Println(err.Error())
 		}
-		if c.Param("id") != "" {
-			f.PollID, _ = strconv.ParseInt(c.Param("id"), 10, 64)
+		if c.Param("id") != "list" {
+			return errors.New("Invalid route variable")
 		}
 		return err
 	}
@@ -221,19 +221,32 @@ func (f *ListPicksFilter) Parse() func(s *SQLO) {
 	return func(s *SQLO) {
 		s.where = append(s.where, sqlsv{statement: "active = ?", variable: f.Active})
 
-		if f.PollID != 0 {
-			s.where = append(s.where, sqlsv{statement: "poll_id = ?", variable: f.PollID})
+		if f.PollID != "" {
+			condition, value, err := ParamsParser(f.PollID, "comma-separated")
+			if err != nil {
+				log.Printf(err.Error())
+				return
+			}
+			i := 0
+			for i < len(condition) {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("poll_id %s (?)", OperatorParser(condition[i])), variable: value[i]})
+				i++
+			}
 		}
-
-		if f.Member != 0 {
-			s.where = append(s.where, sqlsv{statement: "member_id = ?", variable: f.Member})
+		if f.MemberID != 0 {
+			s.where = append(s.where, sqlsv{statement: "member_id = ?", variable: f.MemberID})
 		}
-		// Parse format like: created_at=gte:2018-11-22, lt:2018-11-24
+		// Parse format like: created_at=gte:2018-11-22, lt:2018-11-2
 		if f.CreatedAt != "" {
-			cutter := regexp.MustCompile(`\s*(?P<operator>gte|gt|lte|lt|eq|neq)\s*:(?P<data>[0-9-]+)`)
-			cutted := cutter.FindAllStringSubmatch(f.CreatedAt, -1)
-			for _, filter := range cutted {
-				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("created_at %s ?", OperatorParser(filter[1])), variable: filter[2]})
+			condition, value, err := ParamsParser(f.CreatedAt, "datetime")
+			if err != nil {
+				log.Printf(err.Error())
+				return
+			}
+			i := 0
+			for i < len(condition) {
+				s.where = append(s.where, sqlsv{statement: fmt.Sprintf("created_at %s ?", OperatorParser(condition[i])), variable: value[i]})
+				i++
 			}
 		}
 	}

--- a/poll/model.go
+++ b/poll/model.go
@@ -61,7 +61,8 @@ type ChosenChoice struct {
 // Corresponding choices are embedded in the return values
 type ChoicesEmbeddedPoll struct {
 	Poll
-	Choices []Choice `json:"choices,omitempty" db:"choices"`
+	CreatedBy models.Stunt `json:"created_by" db:"created_by"`
+	Choices   []Choice     `json:"choices,omitempty" db:"choices"`
 }
 
 type pollInterface interface {
@@ -303,6 +304,7 @@ func (p *pollData) Get(filter *ListPollsFilter) (polls []ChoicesEmbeddedPoll, er
 		return nil, err
 	}
 	args = append(args, subArgs...)
+	// fmt.Printf("sql query:%s\n, args:%v\n", query, args)
 
 	rows, err := models.DB.Queryx(query, args...)
 	if err != nil {
@@ -314,7 +316,8 @@ ScanLoop:
 		// Corresponding struct for joined table
 		var poll struct {
 			Poll
-			Choice `db:"choice"`
+			CreatedBy models.Stunt `db:"created_by"`
+			Choice    `db:"choice"`
 		}
 		if err = rows.StructScan(&poll); err != nil {
 			log.Fatal("Error scan polls\n", err)
@@ -331,9 +334,9 @@ ScanLoop:
 		}
 		// Poll id not existing. Create new poll for this id
 		if poll.Choice.ID != 0 {
-			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll, Choices: []Choice{poll.Choice}})
+			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll, CreatedBy: poll.CreatedBy, Choices: []Choice{poll.Choice}})
 		} else {
-			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll})
+			polls = append(polls, ChoicesEmbeddedPoll{Poll: poll.Poll, CreatedBy: poll.CreatedBy})
 		}
 	}
 	return polls, err

--- a/poll/model.go
+++ b/poll/model.go
@@ -514,6 +514,8 @@ func (s *pickData) Get(filter *ListPicksFilter) (picks []ChosenChoice, err error
 		s.fields = append(s.fields, sqlfield{table: "polls_chosen_choice", pattern: `%s.%s`, fields: []string{"*"}})
 	}, filter.Parse())
 	query, args, err := osql.SQL()
+	// fmt.Printf("SQL query:%s,\nargs:%v\n", query, args)
+
 	if err != nil {
 		return nil, err
 	}

--- a/poll/router.go
+++ b/poll/router.go
@@ -2,6 +2,7 @@ package poll
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -148,7 +149,12 @@ func (r *router) PutChoices(c *gin.Context) {
 func (r *router) GetPicks(c *gin.Context) {
 	filter, err := SetListPicksFilter(BindListPicksFilter(c))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		switch err.Error() {
+		case "Invalid route variable":
+			c.JSON(http.StatusBadRequest, gin.H{"Error": fmt.Sprintf("%s. Use /polls/list/picks", err.Error())})
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
+		}
 		return
 	}
 	picks, err := PickData.Get(filter)


### PR DESCRIPTION
## Changelog
### Embed `created_by`
As stated in #302  `embed` filter now could accept two variable: `choices` and `created_by` in comma-separated format, like this: `embed=choices,created_by`. Please notice there shouldn't be blank befor/after comma, or it will cause parsing problem.

The format for `created_by` is modified to accommodate the implementation of this feature. It returned simple integer, as member id before: 
```json
created_by: 648
```
, while now it returns an object: 
```json
created_by: {
   "nickname": "神力女超人"
}
```

*If you don't include `created_by` in `embed` filter, API will still change the format very much like above, only that it's not nickname but id instead in the object:*
```json
created_by: {
   "id": 648
}
```

It only return embedded `nickname` info for `created_by`

### Filter on chosen choices with `member_id`, `poll_id`, `created_at`
**route:** `/v2/polls/list/picks?member_id=123&poll_id=in:[1,2,3,9]&created_at=gte:2018-11-24T15:04:05Z,lt:2018-11-28T15:04:05Z`

As we discussed in #296 , in this pull request I provided further support for filters `member_id`, `poll_id`, `created_by`. 

- `member_id` denotes a single integer, it's used like `member_id=648`
- `poll_id` uses syntax like <operator>:<poll_id array>. It's used as `poll_id=in:[1,2,3,9]`
- `created_at` is a datetime filter, so its syntax is used as before: `created_at=gte:2018-11-24T15:04:05Z,lt:2018-11-28T15:04:05Z`