### PR TITLE
Fixes #305

### DIFF
--- a/poll/model.go
+++ b/poll/model.go
@@ -591,7 +591,7 @@ func (s *pickData) Update(pick ChosenChoice) (err error) {
 	}
 
 	// If set picks to not active(in effect delete), minus total_vote for poll and polls_choices
-	if pick.Active {
+	if !pick.Active {
 
 		if _, err = tx.Exec(`UPDATE polls_choices SET total_vote = total_vote - 1 WHERE id = ?;`, pick.ChoiceID); err != nil {
 			return err

--- a/poll/router.go
+++ b/poll/router.go
@@ -43,7 +43,7 @@ func (r *router) GetPolls(c *gin.Context) {
 // and create new poll using input data
 func (r *router) PostPolls(c *gin.Context) {
 
-	poll := ChoicesEmbeddedPoll{}
+	poll := PollDeserializer{}
 	if err := c.Bind(&poll); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"Error": err.Error()})
 		return

--- a/poll/router.go
+++ b/poll/router.go
@@ -186,6 +186,20 @@ type PubsubData struct {
 	Message      PubsubMessage
 }
 
+// Push accepts message from Google Pub/Sub in format:
+// {
+//   "message": {
+//     "attributes": {
+//       "action": "insert/update"
+//     },
+//     "data": "{"id":1, "member_id": 1, "poll_id": 1, "choice_id":3, "active": true}"
+//     "message_id": "136969346945"
+//   },
+//   "subscription": "projects/myproject/subscriptions/mysubscription"
+// }
+//
+// According to "action" in attributes, Push will call corresponding functions in models.go
+// and execute insert/update for each picks.
 func (r *router) Push(c *gin.Context) {
 
 	var (


### PR DESCRIPTION
## Changelog
### Fixed the improper update issue for total_vote
In previous commits, when invalidate a polls_chosen_choice, API should have stepped-down the `total_vote` in both `polls` and `polls_choices`. In this pull request the logic is fixed.

### Separated the serializer/deserializer for polls
As stated in #305, the root cause is due to the change of struct `ChoiceEmbeddedPoll` for GET API. In this pull request, serializer: `PollSerializer` and deserializer: `PollDeserializer` were created for JSON output and input correspondingly. This could decouple the GET-INSERT JSON fields and suitable for potential further customization.
