### PR TITLE
Post API modifications for memo/reports compatibility

### DIFF
--- a/integration_test/integrate_following_test.go
+++ b/integration_test/integrate_following_test.go
@@ -226,13 +226,13 @@ func TestFollowing(t *testing.T) {
 	t.Run("GetFollowings", func(t *testing.T) {
 		defer init()()
 		for _, tc := range []genericRequestTestcase{
-			genericRequestTestcase{"FollowingPostOK", "GET", `/following/user?resource=post&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[2], mockedFollowings[3]}}},
+			genericRequestTestcase{"FollowingPostOK", "GET", `/following/user?resource=post&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[3], mockedFollowings[2]}}},
 			genericRequestTestcase{"FollowingPostReviewOK", "GET", `/following/user?resource=post&resource_type=review&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[2]}}},
 			genericRequestTestcase{"FollowingPostNewsOK", "GET", `/following/user?resource=memo&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[3]}}},
 			genericRequestTestcase{"FollowingProjectOK", "GET", `/following/user?resource=project&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[5]}}},
 			genericRequestTestcase{"FollowingWithTargetIDsOK", "GET", `/following/user?resource=project&id=1&target_ids=[1,2,3]`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[5]}}},
 			genericRequestTestcase{"FollowingWithModeIDOK", "GET", `/following/user?resource=project&id=1&mode=id`, ``, http.StatusOK, `{"_items":[2]}`, nil},
-			genericRequestTestcase{"FollowingMultipleRes", "GET", `/following/user?resource=["post", "project"]&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[2], mockedFollowings[3], mockedFollowings[5]}}},
+			genericRequestTestcase{"FollowingMultipleRes", "GET", `/following/user?resource=["post", "project"]&id=1`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[3], mockedFollowings[2], mockedFollowings[5]}}},
 			genericRequestTestcase{"FollowingMaxresultPaging", "GET", `/following/user?resource=["post", "project"]&id=1&max_result=1&page=2`, ``, http.StatusOK, ``, []interface{}{[]routes.PubsubFollowMsgBody{mockedFollowings[3]}}},
 			genericRequestTestcase{"FollowingBadID", "GET", `/following/user?resource=post&max_result=1`, ``, http.StatusBadRequest, `{"Error":"Bad Resource ID"}`, nil},
 			genericRequestTestcase{"FollowingBadType", "GET", `/following/user?resource=["post", "aaa"]&id=1`, ``, http.StatusBadRequest, `{"Error":"Bad Following Type"}`, nil},

--- a/integration_test/integrate_post_test.go
+++ b/integration_test/integrate_post_test.go
@@ -97,7 +97,7 @@ func TestPost(t *testing.T) {
 			genericRequestTestcase{"GetPostOK", "GET", `/post/1`, ``, http.StatusOK, ``, []interface{}{[]models.Post{
 				mockedPosts[0],
 			}}},
-			genericRequestTestcase{"NotExisted", "GET", `/post/3`, `{"Error":"Post Not Found"}`, http.StatusNotFound, `{"Error":"Post Not Found"}`, nil},
+			genericRequestTestcase{"NotExisted", "GET", `/post/12345`, `{"Error":"Post Not Found"}`, http.StatusNotFound, `{"Error":"Post Not Found"}`, nil},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				code, resp := genericDoRequest(tc, t)
@@ -111,7 +111,6 @@ func TestPost(t *testing.T) {
 					if err != nil {
 						t.Errorf("%s, Unexpected result body: %v", resp)
 					}
-
 					var expected []models.Post = tc.misc[0].([]models.Post)
 					assertIntHelper(t, tc.name, "result length", len(expected), len(Response.Items))
 					for i, r := range Response.Items {

--- a/integration_test/integrate_report_test.go
+++ b/integration_test/integrate_report_test.go
@@ -161,7 +161,7 @@ func TestReport(t *testing.T) {
 				[]interface{}{[]models.Post{mockedPosts[2], mockedPosts[0]}},
 			},
 			genericRequestTestcase{"GetReportWithMultipleSorting", "GET", `/report/list?sort=-slug,id`, ``, http.StatusOK, ``,
-				[]interface{}{[]models.Post{mockedPosts[0], mockedPosts[1], mockedPosts[2]}},
+				[]interface{}{[]models.Post{mockedPosts[2], mockedPosts[1], mockedPosts[0]}},
 			},
 			genericRequestTestcase{"GetReportKeywordMatchTitle", "GET", `/report/list?keyword=03&active={"$in":[0,1]}`, ``, http.StatusOK, ``,
 				[]interface{}{[]models.Post{mockedPosts[2]}},

--- a/integration_test/integrate_tag_test.go_
+++ b/integration_test/integrate_tag_test.go_
@@ -1,0 +1,201 @@
+//+build integration
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/readr-media/readr-restful/models"
+	"github.com/readr-media/readr-restful/routes"
+)
+
+func TestFollowing(t *testing.T) {
+	var mockedPosts = []models.Post{
+		models.Post{
+			ID:            1,
+			Author:        models.NullInt{1, true},
+			Title:         models.NullString{"Test post 01", true},
+			Content:       models.NullString{"<p>Test post content 01</p>", true},
+			Type:          models.NullInt{0, true},
+			Link:          models.NullString{"http://dev.readr.tw/post/1", true},
+			Active:        models.NullInt{1, true},
+			PublishStatus: models.NullInt{2, true},
+			UpdatedAt:     models.NullTime{Time: time.Date(2018, 1, 2, 3, 4, 5, 6, time.UTC), Valid: true},
+		},
+		models.Post{
+			ID:            2,
+			Author:        models.NullInt{1, true},
+			Title:         models.NullString{"Test report 01", true},
+			Content:       models.NullString{"<p>Test report content 01</p>", true},
+			Type:          models.NullInt{4, true},
+			Link:          models.NullString{"http://dev.readr.tw/project/report_slug_1", true},
+			Active:        models.NullInt{1, true},
+			PublishStatus: models.NullInt{2, true},
+			UpdatedAt:     models.NullTime{Time: time.Date(2018, 1, 3, 3, 4, 5, 6, time.UTC), Valid: true},
+			ProjectID:     models.NullInt{1, true},
+			Slug:          models.NullString{"report_slug_1", true},
+		},
+		models.Post{
+			ID:            3,
+			Author:        models.NullInt{1, true},
+			Title:         models.NullString{"Test memo 01", true},
+			Type:          models.NullInt{5, true},
+			Link:          models.NullString{"http://dev.readr.tw/series/project_slug_2/3", true},
+			Active:        models.NullInt{1, true},
+			PublishStatus: models.NullInt{2, true},
+			UpdatedAt:     models.NullTime{Time: time.Date(2018, 1, 4, 3, 4, 5, 6, time.UTC), Valid: true},
+			ProjectID:     models.NullInt{2, true},
+			Slug:          models.NullString{"project_slug_2", true},
+		},
+	}
+	var mockedMembers = []models.Member{
+		models.Member{
+			ID:       1,
+			UUID:     "uuid1",
+			Mail:     models.NullString{"testmember01@test.cc", true},
+			Nickname: models.NullString{"test_member_01", true},
+			MemberID: "testmember01@test.cc",
+		},
+	}
+	var mockedProjects = []models.Project{
+		models.Project{
+			ID:            1,
+			Slug:          models.NullString{"project_slug_1", true},
+			Title:         models.NullString{"project_title_1", true},
+			PublishStatus: models.NullInt{1, true},
+		},
+	}
+	var mockedTags = []models.Tag{
+		models.Tag{
+			ID:   1,
+			Text: "tag_1",
+		}, models.Tag{
+			ID:   2,
+			Text: "tag_2",
+		}, models.Tag{
+			ID:   3,
+			Text: "tag_3",
+		},
+	}
+	type mockedTagging struct {
+		ResourceType int
+		TargetID     int
+		TagIDs       []int
+	}
+	var mockedTaggings = []mockedTagging{
+		mockedTagging{},
+	}
+
+	transformCommentPubsubMsg := func(name string, msgType string, method string, body []byte) genericRequestTestcase {
+		meta := routes.PubsubMessageMeta{
+			Subscription: "sub",
+			Message: routes.PubsubMessageMetaBody{
+				ID:   "1",
+				Body: body,
+				Attr: map[string]string{"type": msgType, "action": method},
+			},
+		}
+		return genericRequestTestcase{name: name, method: "POST", url: "/restful/pubsub", body: meta}
+	}
+
+	init := func() func() {
+		for _, v := range mockedPosts {
+			_, err := models.PostAPI.InsertPost(v)
+			if err != nil {
+				t.Fatalf("init post data fail: %s ", err.Error())
+			}
+		}
+		for _, v := range mockedMembers {
+			_, err := models.MemberAPI.InsertMember(v)
+			if err != nil {
+				log.Println(err.Error())
+				t.Fatalf("init member data fail: %s ", err.Error())
+			}
+		}
+		for _, v := range mockedProjects {
+			err := models.ProjectAPI.InsertProject(v)
+			if err != nil {
+				t.Fatalf("init project data fail: %s ", err.Error())
+			}
+		}
+		for _, v := range mockedTags {
+			_, err := models.TagAPI.InsertTag(v)
+			if err != nil {
+				t.Fatalf("init tag data fail: %s ", err.Error())
+			}
+		}
+		return flushDB
+	}
+	t.Run("GetTags", func(t *testing.T) {
+		defer init()()
+		for _, tc := range []genericRequestTestcase{
+			genericTestcase{"GetTagBasicOK", "GET", "/tags?stats=0", ``, http.StatusOK, ``, []interface{}{mockedTags}},
+			genericTestcase{"GetTagMaxresultOK", "GET", "/tags?stats=0&max_result=1", ``, http.StatusOK, ``, []interface{}{[]models.Tag{mockedTags[0]}}},
+			genericTestcase{"GetTagPaginationOK", "GET", "/tags?stats=0&max_result=1&page=2", ``, http.StatusOK, ``, []interface{}{[]models.Tag{mockedTags[1]}}},
+			genericTestcase{"GetTagKeywordAndStatsOK", "GET", "/tags?stats=1&keyword=tag2", ``, http.StatusOK, ``, []interface{}{[]models.Tag{mockedTags[1]}}},
+			genericTestcase{"GetTagSortingOK", "GET", "/tags?keyword=tag&sort=-id", ``, http.StatusOK, ``, []interface{}{mockedTags[2], mockedTags[1], mockedTags[0]}},
+			genericTestcase{"GetTagKeywordNotFound", "GET", "/tags?keyword=1024", ``, http.StatusOK, `{"_items":[]}`},
+			genericTestcase{"GetTagUnknownSortingKey", "GET", "/tags?sort=unknown", ``, http.StatusBadRequest, `{"Error":"Bad Sorting Option"}`},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				code, resp := genericDoRequest(tc, t)
+				assertIntHelper(t, tc.name, "status code", tc.httpcode, code)
+				if statusCodeOKHelper(code) && tc.resp == "" {
+					var expected []models.Tag = tc.misc[0].([]models.Tag)
+					for i, r := range Response.Items {
+						assertIntHelper(t, tc.name, "following resource id", int(expected[i].Object), int(r.Item.ID))
+					}
+				} else {
+					assertStringHelper(t, tc.name, "request result", tc.resp, resp)
+				}
+			})
+		}
+	}) /*
+		t.Run("GetTaggedResources", func(t *testing.T) {
+			defer init()()
+			for _, tc := range []genericRequestTestcase{
+				genericRequestTestcase{"GetTagGetTaggedResources", "GET", `/tags?tagged_resources=1`, ``, http.StatusOK, `{"_items":[{"active":1,"created_at":"2018-08-10T12:56:57Z","id":1,"tagged_posts":[{"active":1,"author":931,"id":42,"type":0,"updated_by":931},{"active":1,"author":931,"id":44,"type":0,"updated_by":931}],"text":"tag1","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":2,"tagged_posts":[{"active":1,"author":931,"id":42,"type":0,"updated_by":931}],"text":"tag2","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":3,"tagged_posts":[{"active":1,"author":931,"id":44,"type":0,"updated_by":931}],"text":"tag3","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":4,"text":"tag4","updated_at":"2018-08-10T12:56:57Z","updated_by":931}]}`},
+				genericRequestTestcase{"GetTagGetTaggedResources", "GET", `/tags?post_fields=["unknown"]`, ``, http.StatusBadRequest, `{"Error":"Invalid Fields"}`},
+				genericRequestTestcase{"GetTagGetTaggedResources", "GET", `/tags?tagged_resources=1&post_fields=["post_id"]`, ``, http.StatusOK, `{"_items":[{"active":1,"created_at":"2018-08-10T12:56:57Z","id":1,"tagged_posts":[{"id":42},{"id":44}],"text":"tag1","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":2,"tagged_posts":[{"id":42}],"text":"tag2","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":3,"tagged_posts":[{"id":44}],"text":"tag3","updated_at":"2018-08-10T12:56:57Z","updated_by":931},{"active":1,"created_at":"2018-08-10T12:56:57Z","id":4,"text":"tag4","updated_at":"2018-08-10T12:56:57Z","updated_by":931}]}`},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					code, resp := genericDoRequest(tc, t)
+					assertIntHelper(t, tc.name, "status code", tc.httpcode, code)
+					if statusCodeOKHelper(code) && tc.resp == "" {
+						var Response struct {
+							Items []struct {
+								Item struct {
+									ID int `json:"id"`
+								} `json:"item"`
+							} `json:"_items"`
+						}
+						err := json.Unmarshal([]byte(resp), &Response)
+						if err != nil {
+							t.Fatalf("%s, Unexpected result body: %v", resp)
+							return
+						}
+						var expected []routes.PubsubFollowMsgBody = tc.misc[0].([]routes.PubsubFollowMsgBody)
+						for i, r := range Response.Items {
+							assertIntHelper(t, tc.name, "following resource id", int(expected[i].Object), int(r.Item.ID))
+						}
+					} else {
+						assertStringHelper(t, tc.name, "request result", tc.resp, resp)
+					}
+				})
+			}
+		})
+		t.Run("InsertTags", func(t *testing.T) {})
+		t.Run("UpdateTags", func(t *testing.T) {})
+		t.Run("DeleteTags", func(t *testing.T) {})
+		t.Run("CountTags", func(t *testing.T) {})
+		t.Run("GetHotTags", func(t *testing.T) {})
+		t.Run("UpdateHotTags", func(t *testing.T) {})
+		t.Run("GetPNRofTags", func(t *testing.T) {})
+	*/
+}

--- a/routes/post.go
+++ b/routes/post.go
@@ -55,11 +55,14 @@ func (r *postHandler) bindQuery(c *gin.Context, args *models.PostArgs) (err erro
 			return err
 		}
 	}
-
 	if c.Query("sort") != "" && r.validatePostSorting(c.Query("sort")) {
 		args.Sorting = c.Query("sort")
 	}
-
+	if c.Query("ids") != "" {
+		if err = json.Unmarshal([]byte(c.Query("ids")), &args.IDs); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
1. Remove auto set type constraints if type parameter not set when calling "GET /posts".
2. Remove type constraints when updating post cache, memo and reports are included in post caches now.
3. Add new options "show_project" and "ids" when calling "GET /posts".