### PR TITLE
Fix package version of gin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 
 deps:
 	go get -v -d
+	cd $(GOPATH)/src/github.com/gin-gonic/gin && git checkout tags/v1.3.0  && cd -
 test:
 	go test -v ./...
 run:

--- a/routes/comment_test.go
+++ b/routes/comment_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/readr-media/readr-restful/models"
 )
 
+type mockCommentCache struct{}
+
+func (m *mockCommentCache) Obtain() (comments []models.CommentAuthor, err error) { return comments, nil }
+func (m *mockCommentCache) Insert(comment models.CommentAuthor) (err error)      { return nil }
+func (m *mockCommentCache) Generate() (err error)                                { return nil }
+
 type mockCommentAPI struct{}
 
 func (c *mockCommentAPI) GetComments(args *models.GetCommentArgs) (result []models.CommentAuthor, err error) {

--- a/routes/router_test.go
+++ b/routes/router_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 	models.NotificationGen = new(mockNotificationGenerator)
 
 	models.FollowCache = new(mockFollowCache)
-	//models.CommentCache = new(mockCommentCache)
+	models.CommentCache = new(mockCommentCache)
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
1. Fix the version of gin by checking out the source code version before build, will use the dependence version control tool in the future.
2. Mock the comment cache to fix the router testing.