### PR TITLE
Change of points API for READr 2.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,6 +87,7 @@ type appConfig struct {
 		FollowingType         map[string]int `mapstructure:"following_type"`
 		Emotions              map[string]int `mapstructure:"emotions"`
 		PointType             map[string]int `mapstructure:"point_type"`
+		PointStatus           map[string]int `mapstructure:"point_status"`
 		HotTagsWeight         map[string]int `mapstructure:"hot_tags_wieght"`
 	} `mapstructure:"models"`
 

--- a/db_schema/28_points_currency_and_status.down.sql
+++ b/db_schema/28_points_currency_and_status.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE points DROP COLUMN currency;
+ALTER TABLE points DROP COLUMN status;

--- a/db_schema/28_points_currency_and_status.up.sql
+++ b/db_schema/28_points_currency_and_status.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE points ADD COLUMN currency int(11) NOT NULL DEFAULT 0 AFTER points;
+ALTER TABLE points ADD COLUMN status tinyint unsigned DEFAULT 0;


### PR DESCRIPTION
1. Add new object type to points API: Donate
2. Since Tappay did not provide two-phace commit API such like "commit", I add "status" field to points table for payment status handling, will rollback the transaction when payment process fail.