### PR TITLE
Minor Features: post API / project API

### DIFF
--- a/db_schema/31_post_table_default_project_id.down.sql
+++ b/db_schema/31_post_table_default_project_id.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts MODIFY COLUMN project_id bigint(20) unsigned DEFAULT NULL;
+UPDATE posts SET project_id = NULL WHERE project_id =0;

--- a/db_schema/31_post_table_default_project_id.up.sql
+++ b/db_schema/31_post_table_default_project_id.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts MODIFY COLUMN project_id bigint(20) unsigned DEFAULT 0;
+UPDATE posts SET project_id = 0 WHERE project_id IS NULL;

--- a/routes/project.go
+++ b/routes/project.go
@@ -331,7 +331,7 @@ func (r *projectHandler) validateProjectStatus(i int64) bool {
 
 func (r *projectHandler) validateProjectSorting(sort string) bool {
 	for _, v := range strings.Split(sort, ",") {
-		if matched, err := regexp.MatchString("-?(updated_at|published_at|project_id|project_order|status|slug)", v); err != nil || !matched {
+		if matched, err := regexp.MatchString("-?(created_at|updated_at|published_at|project_id|project_order|status|slug)", v); err != nil || !matched {
 			return false
 		}
 	}


### PR DESCRIPTION
1. Set post's default project_id to 0, set all NULL project_id to 0 in post table. Posts which don't belong to any projects are searchable via "project_id=0" now.
2. Add "created_at" to sorting options for GET /project/list API.