### PR TITLE
Support active filter to promotion API

### DIFF
--- a/pkg/promotion/http/filter.go
+++ b/pkg/promotion/http/filter.go
@@ -73,18 +73,18 @@ func NewListParams(options ...func(*ListParams) (err error)) (*ListParams, error
 }
 
 func (p *ListParams) validate() (err error) {
+
 	// Validate sort fields
 	for _, v := range strings.Split(p.Sort, ",") {
-		if matched, err := regexp.MatchString("-?(updated_at|created_at|id|order)", v); err != nil || !matched {
-			return errors.New("invalid sort")
+		if matched, e := regexp.MatchString("-?(updated_at|created_at|id|order)", v); e != nil || !matched {
+			err = errors.New("invalid sort")
 		}
 	}
-
 	// If Active is empty, set default to active before parsing
 	if len(p.Active) == 0 {
 		p.Active = map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}
 	}
-	return nil
+	return err
 }
 
 // Parse will populate the SQLO in ListParams

--- a/pkg/promotion/http/filter.go
+++ b/pkg/promotion/http/filter.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/readr-media/readr-restful/config"
 	"github.com/readr-media/readr-restful/pkg/promotion/mysql"
 )
 
@@ -16,11 +17,44 @@ type ListParams struct {
 	Sort      string `form:"sort"`
 
 	// Status string
-	// Active *int64
+	Active map[string][]int
 
 	// Embedded SQLO in the struct
 	// ListParams could be pass through interface because of decoupled Parse()
 	o *mysql.SQLO
+}
+
+func OperatorParser(operator string) (result string) {
+	switch operator {
+	case "$gte":
+		result = `>=`
+	case "$gt":
+		result = `>`
+	case "$lte":
+		result = `<=`
+	case "$lt":
+		result = `<`
+	case "$neq":
+		result = `!=`
+	case "$eq":
+		result = `=`
+	case "$in":
+		result = `IN`
+	case "$nin":
+		result = `NOT IN`
+	default:
+		result = ``
+	}
+	return result
+}
+
+func isValidActive(option int) bool {
+	for _, c := range config.Config.Models.Promotions {
+		if option == c {
+			return true
+		}
+	}
+	return false
 }
 
 // NewListParams create a new ListParams struct, and modify it with input functions,
@@ -39,12 +73,16 @@ func NewListParams(options ...func(*ListParams) (err error)) (*ListParams, error
 }
 
 func (p *ListParams) validate() (err error) {
-
 	// Validate sort fields
 	for _, v := range strings.Split(p.Sort, ",") {
 		if matched, err := regexp.MatchString("-?(updated_at|created_at|id|order)", v); err != nil || !matched {
 			return errors.New("invalid sort")
 		}
+	}
+
+	// If Active is empty, set default to active before parsing
+	if len(p.Active) == 0 {
+		p.Active = map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}
 	}
 	return nil
 }
@@ -63,6 +101,14 @@ func (p *ListParams) Parse() {
 	}
 	if p.Sort != "" {
 		p.o.FormatOrderBy(p.Sort)
+	}
+	if len(p.Active) != 0 {
+		// append condition to where statements
+		for operator, values := range p.Active {
+			if len(values) > 0 {
+				p.o.Where = append(p.o.Where, mysql.SQLsv{Statement: fmt.Sprintf("active %s (?)", OperatorParser(operator)), Variable: values})
+			}
+		}
 	}
 }
 

--- a/pkg/promotion/http/handler_test.go
+++ b/pkg/promotion/http/handler_test.go
@@ -3,8 +3,10 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/readr-media/readr-restful/config"
 	"github.com/readr-media/readr-restful/models"
 	"github.com/readr-media/readr-restful/pkg/promotion"
 	"github.com/readr-media/readr-restful/pkg/promotion/mock"
@@ -40,10 +43,11 @@ func TestPromotionHandlerList(t *testing.T) {
 		err      string
 	}{
 		// Should we use gomock.Any() to replace &ListParams{}?
-		{"default-params", http.StatusOK, `/promotions`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at"}, ``},
-		{"max-result", http.StatusOK, `/promotions?max_result=25`, &ListParams{MaxResult: 25, Page: 1, Sort: "-created_at"}, ``},
-		{"page", http.StatusOK, `/promotions?page=7`, &ListParams{MaxResult: 15, Page: 7, Sort: "-created_at"}, ``},
-		{"modify-invalid-sort", http.StatusOK, `/promotions?sort=updated_by`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at"}, ``},
+		{"default-params", http.StatusOK, `/promotions`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
+		{"max-result", http.StatusOK, `/promotions?max_result=25`, &ListParams{MaxResult: 25, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
+		{"page", http.StatusOK, `/promotions?page=7`, &ListParams{MaxResult: 15, Page: 7, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
+		{"modify-invalid-sort", http.StatusOK, `/promotions?sort=updated_by`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
+		{"active", http.StatusOK, `/promotions?active=$in:0,1`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{0, 1}}}, ``},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
@@ -213,4 +217,11 @@ func TestPromotionHandlerDelete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMain(m *testing.M) {
+	if err := config.LoadConfig("../../../config", ""); err != nil {
+		panic(fmt.Errorf("Invalid application configuration: %s", err))
+	}
+	os.Exit(m.Run())
 }

--- a/pkg/promotion/http/handler_test.go
+++ b/pkg/promotion/http/handler_test.go
@@ -43,10 +43,10 @@ func TestPromotionHandlerList(t *testing.T) {
 		err      string
 	}{
 		// Should we use gomock.Any() to replace &ListParams{}?
-		{"default-params", http.StatusOK, `/promotions`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
-		{"max-result", http.StatusOK, `/promotions?max_result=25`, &ListParams{MaxResult: 25, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
-		{"page", http.StatusOK, `/promotions?page=7`, &ListParams{MaxResult: 15, Page: 7, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
-		{"modify-invalid-sort", http.StatusOK, `/promotions?sort=updated_by`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{1}}}, ``},
+		{"default-params", http.StatusOK, `/promotions`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}}, ``},
+		{"max-result", http.StatusOK, `/promotions?max_result=25`, &ListParams{MaxResult: 25, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}}, ``},
+		{"page", http.StatusOK, `/promotions?page=7`, &ListParams{MaxResult: 15, Page: 7, Sort: "-created_at", Active: map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}}, ``},
+		{"modify-invalid-sort", http.StatusOK, `/promotions?sort=updated_by`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{config.Config.Models.Promotions["active"]}}}, ``},
 		{"active", http.StatusOK, `/promotions?active=$in:0,1`, &ListParams{MaxResult: 15, Page: 1, Sort: "-created_at", Active: map[string][]int{"$in": []int{0, 1}}}, ``},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/promotion/mysql/query.go
+++ b/pkg/promotion/mysql/query.go
@@ -9,9 +9,9 @@ import (
 	"github.com/readr-media/readr-restful/models"
 )
 
-type sqlsv struct {
-	statement string
-	variable  interface{}
+type SQLsv struct {
+	Statement string
+	Variable  interface{}
 }
 
 type Sqlfield struct {
@@ -56,7 +56,7 @@ type SQLO struct {
 	Join []string
 
 	// Where comprises SQL statements strings in 'WHERE' section
-	Where []sqlsv
+	Where []SQLsv
 
 	// Order by maps to the ORDER BY section in SQL
 	Orderby string
@@ -112,8 +112,8 @@ func (s *SQLO) Select() (query string, args []interface{}, err error) {
 				base.WriteString(" AND")
 			}
 			base.WriteString(" ")
-			base.WriteString(condition.statement)
-			s.Args = append(s.Args, condition.variable)
+			base.WriteString(condition.Statement)
+			s.Args = append(s.Args, condition.Variable)
 		}
 	}
 	if s.Orderby != "" {


### PR DESCRIPTION
This pull request modified the GET function of promotion, and provided `active` filter for it.

# Changelog

## Active filter
The following filter is provided to get promotions with specified active status:

1. `GET /promotions?active=$in:0,1`
The format of `active` query parameter follows the conclusion we made about query parameters. The structure is basically like this:
```bash
active=<operator>:<comma-separated list>::<operator>:<comma-separated list>:: ...
```
- `active` could accept multiple set of conditions. Separate them with double colon `::`
- `<operator>` starts with dollar sign `$`. Now there could be `$gte`, `$gt`, `$lte`, `$lt`, `$neq`, `$eq`, `$in`, and `$nin`. Basically I believe we only need `$in` and `$nin` here
- `<comma-separated list>` is an array containing all the value you want to filter with. **Only valid active values will be parsed. Now the valid active is 0 and 1.**
- If there is no `active` set in query parameter, an equivalent filter `active=$in:1` will be set. This will get you only the active promotions. If you want to list both inactive and active promotions, please set `active=$in:0,1`.

@hsuehyungtan, this fixes #337 
