### PR TITLE
Post API Changes

### DIFF
--- a/config/main_sample.json
+++ b/config/main_sample.json
@@ -118,7 +118,9 @@
             "video": 9,
             "live": 9,
             "report": 9,
-            "memo": 9
+            "memo": 9,
+            "paragragh": 9,
+            "dummy": 9
         },
         "post_publish_status":{
             "unpublish": 9,

--- a/routes/post_test.go
+++ b/routes/post_test.go
@@ -259,7 +259,7 @@ func TestRoutePost(t *testing.T) {
 					[]models.TaggedPostMember{}},
 				genericTestcase{"Type", "GET", `/posts?type={"$in":[1,2]}`, ``, http.StatusOK,
 					[]models.TaggedPostMember{posts[3], posts[1], posts[0]}},
-				genericTestcase{"ShowDetails", "GET", `/posts?show_author=true&show_updater=true&show_tag=true&show_comment=true`, ``, http.StatusOK,
+				genericTestcase{"ShowDetails", "GET", `/posts?show_author=true&show_updater=true&show_tag=true&show_comment=true&show_card=true`, ``, http.StatusOK,
 					[]models.TaggedPostMember{posts[3], posts[1], posts[0], posts[2]}},
 				genericTestcase{"Slug", "GET", `/posts?slug=slug`, ``, http.StatusOK,
 					[]models.TaggedPostMember{posts[0]}},
@@ -277,6 +277,8 @@ func TestRoutePost(t *testing.T) {
 					[]models.TaggedPostMember{posts[0]}},
 				genericTestcase{"NotExisted", "GET", `/post/3`, `{"Error":"Post Not Found"}`, http.StatusNotFound,
 					[]models.TaggedPostMember{}},
+				genericTestcase{"ShowDetails", "GET", `/post/1?show_card=true`, ``, http.StatusOK,
+					[]models.TaggedPostMember{posts[0]}},
 			},
 		},
 		TestStep{


### PR DESCRIPTION
## Post API Changes

1. Add 2 new post types: dummy and paragragh
2. New parameter `show_card` for GET /post and GET/posts

### show_card
**usage: GET /post/1?show_card=true or GET /posts?ids=[1,2]&show_card=1**
- if the parameter value is true or 1, API will add card field taht contains newcard info related to each post in the result
- if the post don't have any newscard related to it, the field will be ommited in the result