### PR TITLE
Bug fix: authors field no show in the get posts API

### DIFF
--- a/models/posts.go
+++ b/models/posts.go
@@ -675,7 +675,8 @@ func (a *postAPI) fetchPostAuthors(ids []int) (authors map[int][]AuthorBasic, er
 		var authorb AuthorBasic
 		e := rows.StructScan(&authorb)
 		if e != nil {
-			return map[int][]AuthorBasic{}, err
+			fmt.Println("Post has no author or the author data don't have a corresponding member")
+			continue
 		}
 		authors[int(authorb.ResourceID.Int)] = append(authors[int(authorb.ResourceID.Int)], authorb)
 	}


### PR DESCRIPTION
Fix that authors won't show in the result of getting posts API when there's any post has no author or any author has no corresponding member data in the result set.

Reason and resolve: 
If there's a scanning error occurred when getting authors of the posts, the function will return an empty author list, I just skip the returning and continue to scan other query results.