### PR TITLE
Filter API: add response meta

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -109,7 +109,7 @@ pipeline:
       branch: [master, dev, stage]
 
   deploy_dev:
-    image: nytimes/drone-gke:develop
+    image: nytimes/drone-gke
     zone: asia-east1-a
     cluster: dev
     namespace: default
@@ -128,7 +128,7 @@ pipeline:
       branch: dev
 
   deploy_stage:
-    image: nytimes/drone-gke:develop
+    image: nytimes/drone-gke
     zone: asia-east1-a
     cluster: prod-readr
     namespace: default

--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -1,0 +1,6 @@
+package args
+
+type ArgsParser interface {
+	//ParseQuery() (restricts string, values []interface{})
+	ParseCountQuery() (restricts string, values []interface{})
+}

--- a/models/filterArgs.go
+++ b/models/filterArgs.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"time"
+)
+
+type FilterArgs struct {
+	MaxResult   int                  `form:"max_result"`
+	Page        int                  `form:"page"`
+	Sorting     string               `form:"sort"`
+	ID          int64                `form:"id"`
+	Slug        string               `form:"slug"`
+	Mail        string               `form:"mail"`
+	Nickname    string               `form:"nickname"`
+	Title       []string             `form:"title"`
+	Description []string             `form:"description"`
+	Content     []string             `form:"content"`
+	Author      []string             `form:"author"`
+	Tag         []string             `form:"tag"`
+	PublishedAt map[string]time.Time `form:"published_at"`
+	CreatedAt   map[string]time.Time `form:"created_at"`
+	UpdatedAt   map[string]time.Time `form:"updated_at"`
+}

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/readr-media/readr-restful/config"
+	"github.com/readr-media/readr-restful/internal/args"
 	"github.com/readr-media/readr-restful/models"
 )
 
@@ -81,7 +82,7 @@ func (a *mockAssetAPI) teardown() {
 	AssetAPI = a.apiBackup
 }
 
-func (a *mockAssetAPI) Count(args *GetAssetArgs) (count int, err error) {
+func (a *mockAssetAPI) Count(args args.ArgsParser) (count int, err error) {
 	return 1, nil
 }
 
@@ -94,7 +95,7 @@ func (a *mockAssetAPI) Delete(ids []int) (err error) {
 	return nil
 }
 
-func (a *mockAssetAPI) FilterAssets(args *GetAssetArgs) (result []FilteredAsset, err error) {
+func (a *mockAssetAPI) FilterAssets(args *FilterAssetArgs) (result []FilteredAsset, err error) {
 	return result, err
 }
 

--- a/routes/post_test.go
+++ b/routes/post_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/readr-media/readr-restful/config"
+	"github.com/readr-media/readr-restful/internal/args"
 	"github.com/readr-media/readr-restful/internal/rrsql"
 	"github.com/readr-media/readr-restful/models"
 )
@@ -184,27 +186,21 @@ func (a *mockPostAPI) DeletePost(id uint32) (err error) {
 	return err
 }
 
-func (a *mockPostAPI) Count(req *models.PostArgs) (result int, err error) {
+func (a *mockPostAPI) Count(req args.ArgsParser) (result int, err error) {
+	query, _ := req.ParseCountQuery()
 	result = 4
 	err = nil
-	// Type
-	if req.Type != nil {
-		if reflect.DeepEqual(req.Type, map[string][]int{"$in": {1, 2}}) {
-			return 3, nil
-		}
-	}
 
-	// CountAuthor
-	if req.Author != nil {
-		if reflect.DeepEqual(req.Author, map[string][]int64{"$nin": {0, 1}}) {
-			return 2, nil
-		}
+	if strings.Contains(query, "posts.type") {
+		return 3, nil
 	}
-	if reflect.DeepEqual(req.Active, map[string][]int{"$nin": {0}}) {
+	if strings.Contains(query, "posts.author") {
+		return 2, nil
+	}
+	if strings.Contains(query, "posts.active NOT IN (?)") {
 		return 4, nil
 	}
-	// CountActive
-	if reflect.DeepEqual(req.Active, map[string][]int{"$in": {0, 1}}) {
+	if strings.Contains(query, "posts.active IN (?)") {
 		return 2, nil
 	}
 	return result, err
@@ -222,7 +218,7 @@ func (a *mockPostAPI) PublishPipeline(ids []uint32) error {
 func (a *mockPostAPI) GetPostAuthor(id uint32) (member models.Member, err error) {
 	return member, nil
 }
-func (a *mockPostAPI) FilterPosts(args *models.PostArgs) (result []models.FilteredPost, err error) {
+func (a *mockPostAPI) FilterPosts(args *models.FilterPostArgs) (result []models.FilteredPost, err error) {
 	return result, err
 }
 

--- a/routes/project_test.go
+++ b/routes/project_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/readr-media/readr-restful/internal/args"
 	"github.com/readr-media/readr-restful/internal/rrsql"
 	"github.com/readr-media/readr-restful/models"
 )
@@ -21,7 +22,7 @@ var mockProjectAuthors = []models.Stunt{}
 
 type mockProjectAPI struct{}
 
-func (a *mockProjectAPI) CountProjects(arg models.GetProjectArgs) (result int, err error) {
+func (a *mockProjectAPI) CountProjects(arg args.ArgsParser) (result int, err error) {
 	return 5, err
 }
 
@@ -134,7 +135,7 @@ func (a *mockProjectAPI) GetContents(id int, args models.GetProjectArgs) (result
 	return nil, err
 }
 
-func (a *mockProjectAPI) FilterProjects(args models.GetProjectArgs) (result []interface{}, err error) {
+func (a *mockProjectAPI) FilterProjects(args *models.FilterProjectArgs) (result []interface{}, err error) {
 	return result, err
 }
 


### PR DESCRIPTION
Add total amount to the result of filter APIs, and refactor the arguments

This changes the following models:
- Post
- Project
- Member
- Assets

Change details:
- Separate filter argument from get argument for each model.
- Make ArgsParser interface for Counting resources, all Count of each resource took this interface as an argument.
- Implement ParseCountQuery for all get and filter arguments.
- Modify tests for the refactored arguments.
- Remove "develop" tag from the publish plug-in image.