### PR TITLE
Fix Ezpay

### DIFF
--- a/pkg/invoice/ezpay/ezpay.go
+++ b/pkg/invoice/ezpay/ezpay.go
@@ -228,6 +228,9 @@ func (c *InvoiceClient) Validate() (err error) {
 					return errors.New("empty buyer_email when carrier_type = 2")
 				}
 				result["CarrierNum"] = result["BuyerEmail"]
+				if _, ok := result["PrintFlag"]; !ok {
+					result["PrintFlag"] = "N"
+				}
 			default:
 				delete(result, "CarrierType")
 				result["PrintFlag"] = "Y"


### PR DESCRIPTION
Set ezpay argument:"PrintFlag" to "N" when "CarrierType" is 2 and "LoveCode" is empty.
This behavior is not documented in the doc bug it causes an error when "PrintFlag" is not set under the criteria.