### PR TITLE
Post API and New Post Type

### DIFF
--- a/config/main_sample.json
+++ b/config/main_sample.json
@@ -116,7 +116,8 @@
             "report": 9,
             "memo": 9,
             "paragragh": 9,
-            "dummy": 9
+            "dummy": 9,
+            "qa": 9
         },
         "post_publish_status":{
             "unpublish": 9,

--- a/models/posts.go
+++ b/models/posts.go
@@ -626,6 +626,10 @@ func (a *postAPI) GetPost(id uint32, req *PostArgs) (post TaggedPostMember, err 
 	if err == nil {
 		post.Authors = authors[int(post.Post.ID)]
 	}
+	tags, err := a.fetchPostTags([]int{int(post.Post.ID)})
+	if err == nil {
+		post.Tags = tags[int(post.Post.ID)]
+	}
 
 	if req.ShowCard {
 		cards, err := a.fetchPostCards([]int{int(post.Post.ID)})


### PR DESCRIPTION
1. Add tag information in the result of Get Post API.
2. Add config for new post type: qa